### PR TITLE
Add project discovery service

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,8 @@ repo's own extension-facing command-line workflow.
   generation, schematic SVG generation, and packetized-I/O debug helpers.
 - [Initial Extension Design](design/initial-extension-design.md) describes the
   proposed feature areas, VS Code surfaces, and implementation boundaries.
+- [Project Discovery](design/project-discovery.md) documents the passive
+  detection rules and capability model for GEnCor-style HDL projects.
 - [MVP Roadmap](design/mvp-roadmap.md) turns the design into a staged
   implementation plan.
 - [CI GHDL Cache Strategy](design/ci-ghdl-cache.md) records how GitHub Actions

--- a/docs/design/project-discovery.md
+++ b/docs/design/project-discovery.md
@@ -1,0 +1,67 @@
+# Project Discovery
+
+HDL Dev discovers projects passively. Discovery reads the workspace filesystem
+and does not run Make, shell scripts, Python, GHDL, Yosys, or `netlistsvg`.
+That keeps discovery available before workspace trust is granted and gives later
+commands a stable model to decide what needs trust-gated execution.
+
+## Candidate Roots
+
+Discovery starts from:
+
+- VS Code workspace folders
+- optional configured roots from `hdlDev.projectRoots`
+
+Workspace folders are searched to a bounded depth for project roots. Configured
+roots are treated as explicit project root candidates. Relative configured roots
+resolve under each workspace folder.
+
+## Detection Rules
+
+A directory is a detected HDL project when it has:
+
+- `Makefile`
+- at least one GEnCor-style spec directory:
+  - `docs/waveforms/specs`
+  - `docs/schematics/specs`
+
+The spec directories are capability signals, not a requirement that both flows
+exist. A waveform-only project and a schematic-only project are both valid HDL
+projects.
+
+Directories with only a `Makefile` are ignored because HDL Dev cannot infer the
+GEnCor-style workflow surface. Directories with only spec folders are also
+ignored because the Makefile is the execution boundary for later commands.
+
+## Project Model
+
+Each discovered project records absolute paths for:
+
+- project root
+- `Makefile`
+- `scripts/deps.sh`
+- waveform and schematic spec directories
+- GHDL build directory: `build/ghdl`
+- wave dump directory: `build/waves`
+- schematic build directory: `build/schematics`
+- CSV build directory: `build/csv`
+- generated waveform SVGs: `docs/waveforms/generated`
+- generated schematic SVGs: `docs/schematics/generated`
+- logs: `logs`
+- plots: `logs/plots`
+
+Optional paths are represented as capabilities with an `available` flag and a
+status such as `present`, `missingOptionalDirectory`, or `missingOptionalFile`.
+Missing optional directories are therefore visible to views and commands without
+failing passive discovery.
+
+## Trust Boundary
+
+The current discovery mode is `passive-file-scan`:
+
+- `executedWorkspaceCommands: false`
+- `requiresWorkspaceTrust: false`
+
+Later workflows can use this model to enable passive browsing in restricted
+mode while keeping Make, dependency scripts, simulation, and artifact generation
+behind workspace trust checks.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,6 +16,7 @@ nav:
   - Integrations:
       - GEnCor: integrations/gencor.md
   - Design:
+      - Project Discovery: design/project-discovery.md
       - Initial Extension Design: design/initial-extension-design.md
       - MVP Roadmap: design/mvp-roadmap.md
       - CI GHDL Cache Strategy: design/ci-ghdl-cache.md

--- a/src/discovery/projectDiscovery.ts
+++ b/src/discovery/projectDiscovery.ts
@@ -1,0 +1,363 @@
+import type { Dirent } from 'node:fs';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+
+export const passiveDiscoveryExecution = {
+	mode: 'passive-file-scan',
+	executedWorkspaceCommands: false,
+	requiresWorkspaceTrust: false,
+} as const;
+
+export type ProjectDiscoverySource = 'workspaceFolder' | 'configuredRoot';
+export type ProjectCapabilityStatus =
+	| 'present'
+	| 'missingOptionalDirectory'
+	| 'missingOptionalFile';
+
+export interface ProjectDiscoveryOptions {
+	readonly workspaceFolderPaths?: readonly string[];
+	readonly configuredRootPaths?: readonly string[];
+	readonly maxSearchDepth?: number;
+}
+
+export interface ProjectCapability {
+	readonly available: boolean;
+	readonly path: string;
+	readonly status: ProjectCapabilityStatus;
+}
+
+export interface HdlProjectModel {
+	readonly rootPath: string;
+	readonly makefilePath: string;
+	readonly sources: readonly ProjectDiscoverySource[];
+	readonly workspaceFolderPaths: readonly string[];
+	readonly dependencyScript: ProjectCapability;
+	readonly specs: {
+		readonly waveform: ProjectCapability;
+		readonly schematic: ProjectCapability;
+	};
+	readonly buildDirectories: {
+		readonly ghdl: ProjectCapability;
+		readonly waves: ProjectCapability;
+		readonly schematics: ProjectCapability;
+		readonly csv: ProjectCapability;
+	};
+	readonly artifactDirectories: {
+		readonly waveformSvgs: ProjectCapability;
+		readonly schematicSvgs: ProjectCapability;
+		readonly logs: ProjectCapability;
+		readonly plots: ProjectCapability;
+	};
+	readonly discovery: typeof passiveDiscoveryExecution;
+}
+
+export interface ProjectDiscoveryResult {
+	readonly discovery: typeof passiveDiscoveryExecution;
+	readonly scannedRootPaths: readonly string[];
+	readonly projects: readonly HdlProjectModel[];
+}
+
+interface CandidateProjectRoot {
+	readonly rootPath: string;
+	readonly sources: Set<ProjectDiscoverySource>;
+	readonly workspaceFolderPaths: Set<string>;
+}
+
+interface ScanRequest {
+	readonly rootPath: string;
+	readonly source: ProjectDiscoverySource;
+	readonly workspaceFolderPath?: string;
+	readonly maxDepth: number;
+}
+
+const defaultMaxSearchDepth = 3;
+
+const projectRelativePaths = {
+	makefile: 'Makefile',
+	dependencyScript: path.join('scripts', 'deps.sh'),
+	waveformSpecs: path.join('docs', 'waveforms', 'specs'),
+	schematicSpecs: path.join('docs', 'schematics', 'specs'),
+	ghdlBuild: path.join('build', 'ghdl'),
+	wavesBuild: path.join('build', 'waves'),
+	schematicBuild: path.join('build', 'schematics'),
+	csvBuild: path.join('build', 'csv'),
+	waveformSvgs: path.join('docs', 'waveforms', 'generated'),
+	schematicSvgs: path.join('docs', 'schematics', 'generated'),
+	logs: 'logs',
+	plots: path.join('logs', 'plots'),
+} as const;
+
+const skippedSearchDirectories = new Set([
+	'.cache',
+	'.git',
+	'.hg',
+	'.svn',
+	'.vscode-test',
+	'node_modules',
+	'out',
+	'site',
+]);
+
+export async function discoverHdlProjects(
+	options: ProjectDiscoveryOptions,
+): Promise<ProjectDiscoveryResult> {
+	const scanRequests = buildScanRequests(options);
+	const candidatesByPath = new Map<string, CandidateProjectRoot>();
+
+	for (const request of scanRequests) {
+		const projectRoots = await findProjectRoots(request.rootPath, request.maxDepth);
+
+		for (const projectRoot of projectRoots) {
+			const candidate = getOrCreateCandidate(candidatesByPath, projectRoot);
+			candidate.sources.add(request.source);
+
+			if (request.workspaceFolderPath !== undefined) {
+				candidate.workspaceFolderPaths.add(request.workspaceFolderPath);
+			}
+		}
+	}
+
+	const projects = await Promise.all(
+		Array.from(candidatesByPath.values(), async (candidate) => inspectCandidateProjectRoot(candidate)),
+	);
+
+	return {
+		discovery: passiveDiscoveryExecution,
+		scannedRootPaths: Array.from(new Set(scanRequests.map((request) => request.rootPath))).sort(),
+		projects: projects
+			.filter((project): project is HdlProjectModel => project !== undefined)
+			.sort((left, right) => left.rootPath.localeCompare(right.rootPath)),
+	};
+}
+
+export async function inspectProjectRoot(rootPath: string): Promise<HdlProjectModel | undefined> {
+	return inspectCandidateProjectRoot(createCandidate(path.resolve(rootPath)));
+}
+
+async function inspectCandidateProjectRoot(
+	candidateRoot: CandidateProjectRoot,
+): Promise<HdlProjectModel | undefined> {
+	const rootPath = candidateRoot.rootPath;
+	const makefilePath = resolveProjectPath(rootPath, projectRelativePaths.makefile);
+	const hasMakefile = await isFile(makefilePath);
+	const waveformSpecs = await directoryCapability(
+		rootPath,
+		projectRelativePaths.waveformSpecs,
+	);
+	const schematicSpecs = await directoryCapability(
+		rootPath,
+		projectRelativePaths.schematicSpecs,
+	);
+
+	if (!hasMakefile || (!waveformSpecs.available && !schematicSpecs.available)) {
+		return undefined;
+	}
+
+	return {
+		rootPath,
+		makefilePath,
+		sources: Array.from(candidateRoot.sources).sort(),
+		workspaceFolderPaths: Array.from(candidateRoot.workspaceFolderPaths).sort(),
+		dependencyScript: await fileCapability(rootPath, projectRelativePaths.dependencyScript),
+		specs: {
+			waveform: waveformSpecs,
+			schematic: schematicSpecs,
+		},
+		buildDirectories: {
+			ghdl: await directoryCapability(rootPath, projectRelativePaths.ghdlBuild),
+			waves: await directoryCapability(rootPath, projectRelativePaths.wavesBuild),
+			schematics: await directoryCapability(rootPath, projectRelativePaths.schematicBuild),
+			csv: await directoryCapability(rootPath, projectRelativePaths.csvBuild),
+		},
+		artifactDirectories: {
+			waveformSvgs: await directoryCapability(rootPath, projectRelativePaths.waveformSvgs),
+			schematicSvgs: await directoryCapability(rootPath, projectRelativePaths.schematicSvgs),
+			logs: await directoryCapability(rootPath, projectRelativePaths.logs),
+			plots: await directoryCapability(rootPath, projectRelativePaths.plots),
+		},
+		discovery: passiveDiscoveryExecution,
+	};
+}
+
+function buildScanRequests(options: ProjectDiscoveryOptions): ScanRequest[] {
+	const maxDepth = Math.max(0, options.maxSearchDepth ?? defaultMaxSearchDepth);
+	const workspaceFolderPaths = (options.workspaceFolderPaths ?? [])
+		.map((workspaceFolderPath) => path.resolve(workspaceFolderPath));
+	const requests: ScanRequest[] = workspaceFolderPaths.map((workspaceFolderPath) => ({
+		rootPath: workspaceFolderPath,
+		source: 'workspaceFolder',
+		workspaceFolderPath,
+		maxDepth,
+	}));
+
+	for (const configuredRootPath of options.configuredRootPaths ?? []) {
+		const resolvedRootPaths = resolveConfiguredRootPath(
+			configuredRootPath,
+			workspaceFolderPaths,
+		);
+
+		for (const resolvedRootPath of resolvedRootPaths) {
+			requests.push({
+				rootPath: resolvedRootPath,
+				source: 'configuredRoot',
+				workspaceFolderPath: findContainingWorkspaceFolder(
+					resolvedRootPath,
+					workspaceFolderPaths,
+				),
+				maxDepth: 0,
+			});
+		}
+	}
+
+	return requests;
+}
+
+function resolveConfiguredRootPath(
+	configuredRootPath: string,
+	workspaceFolderPaths: readonly string[],
+): string[] {
+	if (path.isAbsolute(configuredRootPath)) {
+		return [path.resolve(configuredRootPath)];
+	}
+
+	if (workspaceFolderPaths.length === 0) {
+		return [path.resolve(configuredRootPath)];
+	}
+
+	return workspaceFolderPaths.map((workspaceFolderPath) => (
+		path.resolve(workspaceFolderPath, configuredRootPath)
+	));
+}
+
+function findContainingWorkspaceFolder(
+	projectRootPath: string,
+	workspaceFolderPaths: readonly string[],
+): string | undefined {
+	return workspaceFolderPaths.find((workspaceFolderPath) => {
+		const relativePath = path.relative(workspaceFolderPath, projectRootPath);
+		return relativePath === '' || (!relativePath.startsWith('..') && !path.isAbsolute(relativePath));
+	});
+}
+
+async function findProjectRoots(rootPath: string, maxDepth: number): Promise<string[]> {
+	if (!(await isDirectory(rootPath))) {
+		return [];
+	}
+
+	return findProjectRootsBelow(rootPath, maxDepth, 0);
+}
+
+async function findProjectRootsBelow(
+	rootPath: string,
+	maxDepth: number,
+	currentDepth: number,
+): Promise<string[]> {
+	const inspectedProject = await inspectProjectRoot(rootPath);
+
+	if (inspectedProject !== undefined) {
+		return [inspectedProject.rootPath];
+	}
+
+	if (currentDepth >= maxDepth) {
+		return [];
+	}
+
+	const entries = await readDirectoryEntries(rootPath);
+	const projectRoots: string[] = [];
+
+	for (const entry of entries) {
+		if (!entry.isDirectory() || skippedSearchDirectories.has(entry.name)) {
+			continue;
+		}
+
+		const childProjectRoots = await findProjectRootsBelow(
+			path.join(rootPath, entry.name),
+			maxDepth,
+			currentDepth + 1,
+		);
+		projectRoots.push(...childProjectRoots);
+	}
+
+	return projectRoots;
+}
+
+function getOrCreateCandidate(
+	candidatesByPath: Map<string, CandidateProjectRoot>,
+	rootPath: string,
+): CandidateProjectRoot {
+	const existingCandidate = candidatesByPath.get(rootPath);
+
+	if (existingCandidate !== undefined) {
+		return existingCandidate;
+	}
+
+	const candidate = createCandidate(rootPath);
+	candidatesByPath.set(rootPath, candidate);
+	return candidate;
+}
+
+function createCandidate(rootPath: string): CandidateProjectRoot {
+	return {
+		rootPath,
+		sources: new Set(),
+		workspaceFolderPaths: new Set(),
+	};
+}
+
+async function fileCapability(
+	rootPath: string,
+	relativePath: string,
+): Promise<ProjectCapability> {
+	const fullPath = resolveProjectPath(rootPath, relativePath);
+	const available = await isFile(fullPath);
+
+	return {
+		available,
+		path: fullPath,
+		status: available ? 'present' : 'missingOptionalFile',
+	};
+}
+
+async function directoryCapability(
+	rootPath: string,
+	relativePath: string,
+): Promise<ProjectCapability> {
+	const fullPath = resolveProjectPath(rootPath, relativePath);
+	const available = await isDirectory(fullPath);
+
+	return {
+		available,
+		path: fullPath,
+		status: available ? 'present' : 'missingOptionalDirectory',
+	};
+}
+
+function resolveProjectPath(rootPath: string, relativePath: string): string {
+	return path.join(rootPath, relativePath);
+}
+
+async function isFile(candidatePath: string): Promise<boolean> {
+	try {
+		const stats = await fs.stat(candidatePath);
+		return stats.isFile();
+	} catch {
+		return false;
+	}
+}
+
+async function isDirectory(candidatePath: string): Promise<boolean> {
+	try {
+		const stats = await fs.stat(candidatePath);
+		return stats.isDirectory();
+	} catch {
+		return false;
+	}
+}
+
+async function readDirectoryEntries(rootPath: string): Promise<Dirent[]> {
+	try {
+		return await fs.readdir(rootPath, { withFileTypes: true });
+	} catch {
+		return [];
+	}
+}

--- a/src/test/projectDiscovery.test.ts
+++ b/src/test/projectDiscovery.test.ts
@@ -1,0 +1,191 @@
+import * as assert from 'node:assert';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import {
+	discoverHdlProjects,
+	inspectProjectRoot,
+	passiveDiscoveryExecution,
+} from '../discovery/projectDiscovery';
+
+const tempRoots: string[] = [];
+
+suite('Project Discovery', () => {
+	teardown(async () => {
+		await Promise.all(tempRoots.splice(0).map(async (tempRoot) => {
+			await fs.rm(tempRoot, { recursive: true, force: true });
+		}));
+	});
+
+	test('discovers one GEnCor-style project without executing commands', async () => {
+		const workspacePath = await createTempWorkspace();
+		const projectPath = path.join(workspacePath, 'pcores', 'timer');
+		await createHdlProject(projectPath, {
+			dependencyScript: true,
+			waveformSpecs: true,
+			schematicSpecs: true,
+			artifactDirectories: true,
+		});
+
+		const result = await discoverHdlProjects({
+			workspaceFolderPaths: [workspacePath],
+		});
+
+		assert.deepStrictEqual(result.discovery, passiveDiscoveryExecution);
+		assert.strictEqual(result.projects.length, 1);
+
+		const [project] = result.projects;
+		assert.strictEqual(project.rootPath, projectPath);
+		assert.strictEqual(project.makefilePath, path.join(projectPath, 'Makefile'));
+		assert.deepStrictEqual(project.sources, ['workspaceFolder']);
+		assert.deepStrictEqual(project.workspaceFolderPaths, [workspacePath]);
+		assert.deepStrictEqual(project.discovery, passiveDiscoveryExecution);
+		assert.strictEqual(project.dependencyScript.available, true);
+		assert.strictEqual(project.specs.waveform.available, true);
+		assert.strictEqual(project.specs.schematic.available, true);
+		assert.strictEqual(project.artifactDirectories.waveformSvgs.available, true);
+		assert.strictEqual(project.artifactDirectories.schematicSvgs.available, true);
+		assert.strictEqual(project.discovery.executedWorkspaceCommands, false);
+		assert.strictEqual(project.discovery.requiresWorkspaceTrust, false);
+	});
+
+	test('handles multi-root workspaces and reports missing optional directories as capabilities', async () => {
+		const waveformOnlyProject = await createTempWorkspace();
+		await createHdlProject(waveformOnlyProject, {
+			waveformSpecs: true,
+			schematicSpecs: false,
+		});
+
+		const schematicOnlyProject = await createTempWorkspace();
+		await createHdlProject(schematicOnlyProject, {
+			waveformSpecs: false,
+			schematicSpecs: true,
+		});
+
+		const result = await discoverHdlProjects({
+			workspaceFolderPaths: [schematicOnlyProject, waveformOnlyProject],
+		});
+
+		assert.deepStrictEqual(
+			result.projects.map((project) => project.rootPath),
+			[schematicOnlyProject, waveformOnlyProject].sort(),
+		);
+
+		const waveformProject = result.projects.find((project) => project.rootPath === waveformOnlyProject);
+		assert.ok(waveformProject);
+		assert.strictEqual(waveformProject.specs.waveform.available, true);
+		assert.strictEqual(waveformProject.specs.schematic.available, false);
+		assert.strictEqual(waveformProject.specs.schematic.status, 'missingOptionalDirectory');
+		assert.strictEqual(waveformProject.dependencyScript.available, false);
+		assert.strictEqual(waveformProject.dependencyScript.status, 'missingOptionalFile');
+
+		const schematicProject = result.projects.find((project) => project.rootPath === schematicOnlyProject);
+		assert.ok(schematicProject);
+		assert.strictEqual(schematicProject.specs.waveform.available, false);
+		assert.strictEqual(schematicProject.specs.waveform.status, 'missingOptionalDirectory');
+		assert.strictEqual(schematicProject.specs.schematic.available, true);
+	});
+
+	test('discovers explicitly configured roots relative to workspace folders', async () => {
+		const workspacePath = await createTempWorkspace();
+		const projectPath = path.join(workspacePath, 'third_party', 'hdl', 'uart');
+		await createHdlProject(projectPath, {
+			waveformSpecs: true,
+		});
+
+		const result = await discoverHdlProjects({
+			workspaceFolderPaths: [workspacePath],
+			configuredRootPaths: [path.join('third_party', 'hdl', 'uart')],
+			maxSearchDepth: 1,
+		});
+
+		assert.strictEqual(result.projects.length, 1);
+		assert.strictEqual(result.projects[0].rootPath, projectPath);
+		assert.deepStrictEqual(
+			result.projects[0].sources,
+			['configuredRoot'],
+		);
+		assert.deepStrictEqual(
+			result.projects[0].workspaceFolderPaths,
+			[workspacePath],
+		);
+	});
+
+	test('does not treat partial Makefile or spec layouts as projects', async () => {
+		const workspacePath = await createTempWorkspace();
+		const makefileOnlyPath = path.join(workspacePath, 'makefile-only');
+		await writeFixtureFile(path.join(makefileOnlyPath, 'Makefile'), 'list-tbs:\n');
+
+		const specsOnlyPath = path.join(workspacePath, 'specs-only');
+		await writeFixtureFile(
+			path.join(specsOnlyPath, 'docs', 'waveforms', 'specs', 'timer.json'),
+			'{}\n',
+		);
+
+		const result = await discoverHdlProjects({
+			workspaceFolderPaths: [workspacePath],
+		});
+		const directInspection = await inspectProjectRoot(makefileOnlyPath);
+
+		assert.deepStrictEqual(result.projects, []);
+		assert.strictEqual(directInspection, undefined);
+	});
+});
+
+interface HdlProjectFixtureOptions {
+	readonly dependencyScript?: boolean;
+	readonly waveformSpecs?: boolean;
+	readonly schematicSpecs?: boolean;
+	readonly artifactDirectories?: boolean;
+}
+
+async function createTempWorkspace(): Promise<string> {
+	const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'hdl-dev-discovery-'));
+	tempRoots.push(tempRoot);
+	return tempRoot;
+}
+
+async function createHdlProject(
+	projectPath: string,
+	options: HdlProjectFixtureOptions,
+): Promise<void> {
+	await writeFixtureFile(path.join(projectPath, 'Makefile'), [
+		'list-tbs:',
+		'\t@printf "timer_tb\\n"',
+		'',
+	].join('\n'));
+
+	if (options.dependencyScript === true) {
+		await writeFixtureFile(
+			path.join(projectPath, 'scripts', 'deps.sh'),
+			'#!/usr/bin/env bash\n',
+		);
+	}
+
+	if (options.waveformSpecs === true) {
+		await writeFixtureFile(
+			path.join(projectPath, 'docs', 'waveforms', 'specs', 'timer.json'),
+			'{}\n',
+		);
+	}
+
+	if (options.schematicSpecs === true) {
+		await writeFixtureFile(
+			path.join(projectPath, 'docs', 'schematics', 'specs', 'core.json'),
+			'{}\n',
+		);
+	}
+
+	if (options.artifactDirectories === true) {
+		await fs.mkdir(path.join(projectPath, 'docs', 'waveforms', 'generated'), { recursive: true });
+		await fs.mkdir(path.join(projectPath, 'docs', 'schematics', 'generated'), { recursive: true });
+		await fs.mkdir(path.join(projectPath, 'build', 'waves'), { recursive: true });
+		await fs.mkdir(path.join(projectPath, 'logs', 'plots'), { recursive: true });
+	}
+}
+
+async function writeFixtureFile(filePath: string, content: string): Promise<void> {
+	await fs.mkdir(path.dirname(filePath), { recursive: true });
+	await fs.writeFile(filePath, content, 'utf8');
+}


### PR DESCRIPTION
## Summary

- add a passive HDL project discovery service for GEnCor-style project roots
- expose a project model with Makefile, dependency script, spec, build, and artifact capability paths
- cover one-root, multi-root, configured-root, and partial-layout fixture cases
- document the discovery rules and trust boundary

Refs #1.

## Local Validation

- `npm run compile`
- `npm run lint`
- `git diff --check`
- `make docs-build`
- `env XDG_RUNTIME_DIR=/tmp/hdl-dev-vscode-runtime npm test`

Local VS Code test evidence: `5 passing`, including the four `Project Discovery` tests and the scaffold sample test.

## Remote CI Evidence

- CI: passed - https://github.com/cosgroma/vscode-hdl-dev/actions/runs/24621012488
- Pages: passed - https://github.com/cosgroma/vscode-hdl-dev/actions/runs/24621012487
- Git Flow Policy: passed - https://github.com/cosgroma/vscode-hdl-dev/actions/runs/24621012486
- Doctor GHDL Smoke: passed - https://github.com/cosgroma/vscode-hdl-dev/actions/runs/24621012485