### PR TITLE
Add Dependency Doctor commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,15 +9,48 @@
   "categories": [
     "Other"
   ],
-  "activationEvents": [],
+  "activationEvents": [
+    "onStartupFinished",
+    "onCommand:vscode-hdl-dev.checkGhdlDependencies",
+    "onCommand:vscode-hdl-dev.checkDocsAssetDependencies"
+  ],
   "main": "./out/extension.js",
   "contributes": {
     "commands": [
       {
-        "command": "vscode-hdl-dev.helloWorld",
-        "title": "Hello World"
+        "command": "vscode-hdl-dev.checkGhdlDependencies",
+        "title": "Check GHDL Dependencies",
+        "category": "HDL Dev"
+      },
+      {
+        "command": "vscode-hdl-dev.checkDocsAssetDependencies",
+        "title": "Check Documentation Asset Dependencies",
+        "category": "HDL Dev"
       }
-    ]
+    ],
+    "configuration": {
+      "title": "HDL Dev",
+      "properties": {
+        "hdlDev.projectRoots": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [],
+          "description": "Optional explicit HDL project roots. Relative paths resolve under each workspace folder."
+        },
+        "hdlDev.depsScript": {
+          "type": "string",
+          "default": "scripts/deps.sh",
+          "description": "Path to the dependency script to run from a discovered project or workspace folder."
+        },
+        "hdlDev.toolchainRoot": {
+          "type": "string",
+          "default": "",
+          "description": "Optional GHDL toolchain root. When set, HDL Dev passes it as GHDL_TOOLCHAIN_ROOT and prepends its bin directory to PATH."
+        }
+      }
+    }
   },
   "scripts": {
     "vscode:prepublish": "npm run compile",

--- a/src/doctor/dependencyDoctor.ts
+++ b/src/doctor/dependencyDoctor.ts
@@ -1,0 +1,487 @@
+import { spawn } from 'node:child_process';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+
+import { discoverHdlProjects } from '../discovery/projectDiscovery';
+
+export const checkGhdlDependenciesCommand = 'vscode-hdl-dev.checkGhdlDependencies';
+export const checkDocsAssetDependenciesCommand = 'vscode-hdl-dev.checkDocsAssetDependencies';
+
+export type DependencyCheckProfile = 'ghdl' | 'docs-assets';
+export type DependencyCheckOutcome = 'passed' | 'failed' | 'blocked' | 'noTarget';
+export type DependencyStatusState = 'unknown' | 'checking' | 'passing' | 'failing';
+export type DependencyCheckTargetSource = 'project' | 'workspaceFolder' | 'configuredRoot';
+
+export interface DependencyCheckDefinition {
+	readonly profile: DependencyCheckProfile;
+	readonly label: string;
+	readonly commandTitle: string;
+}
+
+export interface DependencyCheckStatus {
+	readonly state: DependencyStatusState;
+	readonly message: string;
+	readonly profile?: DependencyCheckProfile;
+	readonly targetRootPath?: string;
+	readonly exitCode?: number;
+}
+
+export interface DependencyStatusBarPresentation {
+	readonly text: string;
+	readonly tooltip: string;
+	readonly command: string;
+}
+
+export interface DependencyOutput {
+	append(value: string): void;
+	appendLine(value: string): void;
+	show(preserveFocus?: boolean): void;
+}
+
+export interface DependencyStatusSink {
+	setStatus(status: DependencyCheckStatus): void;
+}
+
+export interface DependencyCheckTarget {
+	readonly rootPath: string;
+	readonly depsScriptPath: string;
+	readonly source: DependencyCheckTargetSource;
+}
+
+export interface DependencyProcessRequest {
+	readonly executablePath: string;
+	readonly args: readonly string[];
+	readonly cwd: string;
+	readonly env: NodeJS.ProcessEnv;
+}
+
+export interface DependencyProcessEvents {
+	readonly onStdout: (chunk: string) => void;
+	readonly onStderr: (chunk: string) => void;
+}
+
+export interface DependencyProcessResult {
+	readonly exitCode: number;
+	readonly signal?: NodeJS.Signals;
+}
+
+export interface DependencyProcessRunner {
+	run(
+		request: DependencyProcessRequest,
+		events: DependencyProcessEvents,
+	): Promise<DependencyProcessResult>;
+}
+
+export interface DependencyCheckOptions {
+	readonly profile: DependencyCheckProfile;
+	readonly workspaceTrusted: boolean;
+	readonly workspaceFolderPaths: readonly string[];
+	readonly configuredRootPaths?: readonly string[];
+	readonly depsScriptRelativePath?: string;
+	readonly env?: NodeJS.ProcessEnv;
+	readonly environmentOverrides?: NodeJS.ProcessEnv;
+	readonly output: DependencyOutput;
+	readonly statusSink?: DependencyStatusSink;
+	readonly runner?: DependencyProcessRunner;
+	readonly showErrorMessage?: (message: string) => PromiseLike<unknown> | unknown;
+}
+
+export interface DependencyCheckResult {
+	readonly outcome: DependencyCheckOutcome;
+	readonly profile: DependencyCheckProfile;
+	readonly target?: DependencyCheckTarget;
+	readonly exitCode?: number;
+	readonly command?: DependencyProcessRequest;
+	readonly message: string;
+}
+
+export interface DependencyCheckTargetOptions {
+	readonly workspaceFolderPaths: readonly string[];
+	readonly configuredRootPaths?: readonly string[];
+	readonly depsScriptRelativePath?: string;
+}
+
+const defaultDependencyScriptPath = path.join('scripts', 'deps.sh');
+
+const dependencyCheckDefinitions: Record<DependencyCheckProfile, DependencyCheckDefinition> = {
+	ghdl: {
+		profile: 'ghdl',
+		label: 'GHDL',
+		commandTitle: 'HDL Dev: Check GHDL Dependencies',
+	},
+	'docs-assets': {
+		profile: 'docs-assets',
+		label: 'documentation asset',
+		commandTitle: 'HDL Dev: Check Documentation Asset Dependencies',
+	},
+};
+
+const environmentSummaryKeys = [
+	'GHDL_TOOLCHAIN_ROOT',
+	'HDL_DEV_GHDL_ROOT',
+	'HDL_DEV_GHDL_BASE',
+	'HDL_DEV_GHDL_TAG',
+];
+
+export const nodeDependencyProcessRunner: DependencyProcessRunner = {
+	run(request, events) {
+		return new Promise((resolve, reject) => {
+			const childProcess = spawn(
+				request.executablePath,
+				[...request.args],
+				{
+					cwd: request.cwd,
+					env: request.env,
+					shell: false,
+				},
+			);
+
+			childProcess.stdout.setEncoding('utf8');
+			childProcess.stderr.setEncoding('utf8');
+			childProcess.stdout.on('data', (chunk: string) => events.onStdout(chunk));
+			childProcess.stderr.on('data', (chunk: string) => events.onStderr(chunk));
+			childProcess.on('error', reject);
+			childProcess.on('close', (code, signal) => {
+				resolve({
+					exitCode: code ?? 1,
+					signal: signal ?? undefined,
+				});
+			});
+		});
+	},
+};
+
+export function createUnknownDependencyStatus(): DependencyCheckStatus {
+	return {
+		state: 'unknown',
+		message: 'Dependency status unknown',
+	};
+}
+
+export function formatDependencyStatusBar(
+	status: DependencyCheckStatus,
+): DependencyStatusBarPresentation {
+	switch (status.state) {
+		case 'checking':
+			return {
+				text: '$(sync~spin) HDL Dev deps',
+				tooltip: status.message,
+				command: commandForProfile(status.profile),
+			};
+		case 'passing':
+			return {
+				text: '$(pass) HDL Dev deps',
+				tooltip: status.message,
+				command: commandForProfile(status.profile),
+			};
+		case 'failing':
+			return {
+				text: '$(error) HDL Dev deps',
+				tooltip: status.message,
+				command: commandForProfile(status.profile),
+			};
+		case 'unknown':
+			return {
+				text: '$(beaker) HDL Dev deps',
+				tooltip: status.message,
+				command: checkGhdlDependenciesCommand,
+			};
+	}
+}
+
+export function buildDependencyCheckEnvironment(
+	baseEnv: NodeJS.ProcessEnv = process.env,
+	overrides: NodeJS.ProcessEnv = {},
+): NodeJS.ProcessEnv {
+	const env: NodeJS.ProcessEnv = {
+		...baseEnv,
+		...overrides,
+	};
+
+	if (env.GHDL_TOOLCHAIN_ROOT !== undefined && env.GHDL_TOOLCHAIN_ROOT.trim() !== '') {
+		const ghdlBinPath = path.join(env.GHDL_TOOLCHAIN_ROOT, 'bin');
+		env.PATH = env.PATH === undefined || env.PATH === ''
+			? ghdlBinPath
+			: `${ghdlBinPath}${path.delimiter}${env.PATH}`;
+	}
+
+	return env;
+}
+
+export async function runDependencyCheck(
+	options: DependencyCheckOptions,
+): Promise<DependencyCheckResult> {
+	const definition = dependencyCheckDefinitions[options.profile];
+	const depsScriptRelativePath = options.depsScriptRelativePath ?? defaultDependencyScriptPath;
+	const runner = options.runner ?? nodeDependencyProcessRunner;
+
+	options.output.show(true);
+
+	if (!options.workspaceTrusted) {
+		const message = 'Workspace trust is required before HDL Dev can run dependency scripts.';
+		writeHeader(options.output, definition, message);
+		options.output.appendLine(`[error] ${message}`);
+		options.statusSink?.setStatus({
+			state: 'failing',
+			profile: options.profile,
+			message,
+		});
+		await notifyError(options, message);
+		return {
+			outcome: 'blocked',
+			profile: options.profile,
+			message,
+		};
+	}
+
+	const target = await findDependencyCheckTarget({
+		workspaceFolderPaths: options.workspaceFolderPaths,
+		configuredRootPaths: options.configuredRootPaths,
+		depsScriptRelativePath,
+	});
+
+	if (target === undefined) {
+		const message = `No ${depsScriptRelativePath} dependency script was found in the workspace.`;
+		writeHeader(options.output, definition, message);
+		options.output.appendLine(`[error] ${message}`);
+		options.statusSink?.setStatus({
+			state: 'failing',
+			profile: options.profile,
+			message,
+		});
+		await notifyError(options, message);
+		return {
+			outcome: 'noTarget',
+			profile: options.profile,
+			message,
+		};
+	}
+
+	const env = buildDependencyCheckEnvironment(
+		options.env ?? process.env,
+		options.environmentOverrides ?? {},
+	);
+	const request: DependencyProcessRequest = {
+		executablePath: target.depsScriptPath,
+		args: ['check', options.profile],
+		cwd: target.rootPath,
+		env,
+	};
+
+	options.statusSink?.setStatus({
+		state: 'checking',
+		profile: options.profile,
+		targetRootPath: target.rootPath,
+		message: `Checking ${definition.label} dependencies`,
+	});
+	writeHeader(options.output, definition, `Running ${definition.commandTitle}`);
+	writeExecutionDetails(options.output, target, request);
+
+	try {
+		const processResult = await runner.run(request, {
+			onStdout: (chunk) => options.output.append(chunk),
+			onStderr: (chunk) => options.output.append(chunk),
+		});
+
+		if (processResult.exitCode === 0) {
+			const message = `${definition.label} dependencies passed`;
+			options.output.appendLine('');
+			options.output.appendLine(`[ok] ${message}`);
+			options.statusSink?.setStatus({
+				state: 'passing',
+				profile: options.profile,
+				targetRootPath: target.rootPath,
+				exitCode: processResult.exitCode,
+				message,
+			});
+			return {
+				outcome: 'passed',
+				profile: options.profile,
+				target,
+				exitCode: processResult.exitCode,
+				command: request,
+				message,
+			};
+		}
+
+		const message = `${definition.label} dependency check failed with exit code ${processResult.exitCode}`;
+		options.output.appendLine('');
+		options.output.appendLine(`[error] ${message}`);
+		options.statusSink?.setStatus({
+			state: 'failing',
+			profile: options.profile,
+			targetRootPath: target.rootPath,
+			exitCode: processResult.exitCode,
+			message,
+		});
+		await notifyError(options, `${message}. See the HDL Dev output channel for details.`);
+		return {
+			outcome: 'failed',
+			profile: options.profile,
+			target,
+			exitCode: processResult.exitCode,
+			command: request,
+			message,
+		};
+	} catch (error) {
+		const message = `Failed to run ${definition.commandTitle}: ${errorMessage(error)}`;
+		options.output.appendLine('');
+		options.output.appendLine(`[error] ${message}`);
+		options.statusSink?.setStatus({
+			state: 'failing',
+			profile: options.profile,
+			targetRootPath: target.rootPath,
+			message,
+		});
+		await notifyError(options, `${message}. See the HDL Dev output channel for details.`);
+		return {
+			outcome: 'failed',
+			profile: options.profile,
+			target,
+			command: request,
+			message,
+		};
+	}
+}
+
+export async function findDependencyCheckTarget(
+	options: DependencyCheckTargetOptions,
+): Promise<DependencyCheckTarget | undefined> {
+	const workspaceFolderPaths = options.workspaceFolderPaths.map((folderPath) => path.resolve(folderPath));
+	const depsScriptRelativePath = options.depsScriptRelativePath ?? defaultDependencyScriptPath;
+	const targetsByScriptPath = new Map<string, DependencyCheckTarget>();
+
+	const discoveryResult = await discoverHdlProjects({
+		workspaceFolderPaths,
+		configuredRootPaths: options.configuredRootPaths,
+	});
+
+	for (const project of discoveryResult.projects) {
+		await addCandidateTarget(
+			targetsByScriptPath,
+			project.rootPath,
+			resolveDepsScriptPath(project.rootPath, depsScriptRelativePath),
+			project.sources.includes('configuredRoot') ? 'configuredRoot' : 'project',
+		);
+	}
+
+	for (const workspaceFolderPath of workspaceFolderPaths) {
+		await addCandidateTarget(
+			targetsByScriptPath,
+			workspaceFolderPath,
+			resolveDepsScriptPath(workspaceFolderPath, depsScriptRelativePath),
+			'workspaceFolder',
+		);
+	}
+
+	return Array.from(targetsByScriptPath.values())
+		.sort(compareDependencyCheckTargets)[0];
+}
+
+function commandForProfile(profile: DependencyCheckProfile | undefined): string {
+	if (profile === 'docs-assets') {
+		return checkDocsAssetDependenciesCommand;
+	}
+
+	return checkGhdlDependenciesCommand;
+}
+
+function compareDependencyCheckTargets(
+	left: DependencyCheckTarget,
+	right: DependencyCheckTarget,
+): number {
+	const priorityDifference = targetSourcePriority(left.source) - targetSourcePriority(right.source);
+
+	if (priorityDifference !== 0) {
+		return priorityDifference;
+	}
+
+	return left.rootPath.localeCompare(right.rootPath);
+}
+
+function targetSourcePriority(source: DependencyCheckTargetSource): number {
+	switch (source) {
+		case 'project':
+			return 0;
+		case 'configuredRoot':
+			return 1;
+		case 'workspaceFolder':
+			return 2;
+	}
+}
+
+async function addCandidateTarget(
+	targetsByScriptPath: Map<string, DependencyCheckTarget>,
+	rootPath: string,
+	depsScriptPath: string,
+	source: DependencyCheckTargetSource,
+): Promise<void> {
+	if (!(await isFile(depsScriptPath)) || targetsByScriptPath.has(depsScriptPath)) {
+		return;
+	}
+
+	targetsByScriptPath.set(depsScriptPath, {
+		rootPath,
+		depsScriptPath,
+		source,
+	});
+}
+
+function resolveDepsScriptPath(rootPath: string, depsScriptPath: string): string {
+	if (path.isAbsolute(depsScriptPath)) {
+		return path.resolve(depsScriptPath);
+	}
+
+	return path.resolve(rootPath, depsScriptPath);
+}
+
+function writeHeader(
+	output: DependencyOutput,
+	definition: DependencyCheckDefinition,
+	message: string,
+): void {
+	output.appendLine('');
+	output.appendLine(`[HDL Dev] ${message}`);
+	output.appendLine(`[HDL Dev] Profile: ${definition.profile}`);
+}
+
+function writeExecutionDetails(
+	output: DependencyOutput,
+	target: DependencyCheckTarget,
+	request: DependencyProcessRequest,
+): void {
+	output.appendLine(`[HDL Dev] Target root: ${target.rootPath}`);
+	output.appendLine(`[HDL Dev] Target source: ${target.source}`);
+	output.appendLine(`[HDL Dev] Executable: ${request.executablePath}`);
+	output.appendLine(`[HDL Dev] Arguments: ${JSON.stringify(request.args)}`);
+	output.appendLine(`[HDL Dev] Working directory: ${request.cwd}`);
+	output.appendLine('[HDL Dev] Environment:');
+	for (const key of environmentSummaryKeys) {
+		output.appendLine(`  ${key}=${request.env[key] ?? '<unset>'}`);
+	}
+	output.appendLine('');
+}
+
+async function notifyError(
+	options: DependencyCheckOptions,
+	message: string,
+): Promise<void> {
+	await options.showErrorMessage?.(message);
+}
+
+async function isFile(candidatePath: string): Promise<boolean> {
+	try {
+		const stats = await fs.stat(candidatePath);
+		return stats.isFile();
+	} catch {
+		return false;
+	}
+}
+
+function errorMessage(error: unknown): string {
+	if (error instanceof Error) {
+		return error.message;
+	}
+
+	return String(error);
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,26 +1,61 @@
-// The module 'vscode' contains the VS Code extensibility API
-// Import the module and reference it with the alias vscode in your code below
 import * as vscode from 'vscode';
 
-// This method is called when your extension is activated
-// Your extension is activated the very first time the command is executed
+import {
+	checkDocsAssetDependenciesCommand,
+	checkGhdlDependenciesCommand,
+	createUnknownDependencyStatus,
+	formatDependencyStatusBar,
+	runDependencyCheck,
+	type DependencyCheckProfile,
+	type DependencyCheckStatus,
+} from './doctor/dependencyDoctor';
+
 export function activate(context: vscode.ExtensionContext) {
+	const outputChannel = vscode.window.createOutputChannel('HDL Dev');
+	const statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 100);
+	const statusSink = {
+		setStatus(status: DependencyCheckStatus): void {
+			const presentation = formatDependencyStatusBar(status);
+			statusBarItem.text = presentation.text;
+			statusBarItem.tooltip = presentation.tooltip;
+			statusBarItem.command = presentation.command;
+			statusBarItem.show();
+		},
+	};
 
-	// Use the console to output diagnostic information (console.log) and errors (console.error)
-	// This line of code will only be executed once when your extension is activated
-	console.log('Congratulations, your extension "vscode-hdl-dev" is now active!');
+	statusSink.setStatus(createUnknownDependencyStatus());
 
-	// The command has been defined in the package.json file
-	// Now provide the implementation of the command with registerCommand
-	// The commandId parameter must match the command field in package.json
-	const disposable = vscode.commands.registerCommand('vscode-hdl-dev.helloWorld', () => {
-		// The code you place here will be executed every time your command is executed
-		// Display a message box to the user
-		vscode.window.showInformationMessage('Hello World from HDL Dev!');
-	});
+	const runDoctorCommand = async (profile: DependencyCheckProfile): Promise<void> => {
+		const configuration = vscode.workspace.getConfiguration('hdlDev');
+		const configuredRootPaths = configuration.get<readonly string[]>('projectRoots', []);
+		const depsScriptRelativePath = configuration.get<string>('depsScript', 'scripts/deps.sh');
+		const toolchainRoot = configuration.get<string>('toolchainRoot', '').trim();
 
-	context.subscriptions.push(disposable);
+		await runDependencyCheck({
+			profile,
+			workspaceTrusted: vscode.workspace.isTrusted,
+			workspaceFolderPaths: vscode.workspace.workspaceFolders?.map((folder) => folder.uri.fsPath) ?? [],
+			configuredRootPaths,
+			depsScriptRelativePath,
+			environmentOverrides: toolchainRoot === '' ? {} : { GHDL_TOOLCHAIN_ROOT: toolchainRoot },
+			output: outputChannel,
+			statusSink,
+			showErrorMessage: (message) => vscode.window.showErrorMessage(message),
+		});
+	};
+
+	context.subscriptions.push(
+		outputChannel,
+		statusBarItem,
+		vscode.commands.registerCommand(
+			checkGhdlDependenciesCommand,
+			() => runDoctorCommand('ghdl'),
+		),
+		vscode.commands.registerCommand(
+			checkDocsAssetDependenciesCommand,
+			() => runDoctorCommand('docs-assets'),
+		),
+	);
 }
 
-// This method is called when your extension is deactivated
 export function deactivate() {}

--- a/src/test/dependencyDoctor.test.ts
+++ b/src/test/dependencyDoctor.test.ts
@@ -1,0 +1,266 @@
+import * as assert from 'node:assert';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import {
+	checkDocsAssetDependenciesCommand,
+	checkGhdlDependenciesCommand,
+	formatDependencyStatusBar,
+	runDependencyCheck,
+	type DependencyCheckStatus,
+	type DependencyOutput,
+	type DependencyProcessEvents,
+	type DependencyProcessRequest,
+	type DependencyProcessResult,
+	type DependencyProcessRunner,
+} from '../doctor/dependencyDoctor';
+
+const tempRoots: string[] = [];
+
+suite('Dependency Doctor', () => {
+	teardown(async () => {
+		await Promise.all(tempRoots.splice(0).map(async (tempRoot) => {
+			await fs.rm(tempRoot, { recursive: true, force: true });
+		}));
+	});
+
+	test('runs GHDL dependency checks with explicit process arguments', async () => {
+		const workspacePath = await createTempWorkspace();
+		const depsScriptPath = await createDepsScript(workspacePath);
+		const output = new CapturingOutput();
+		const statuses = new CapturingStatusSink();
+		const runner = new FakeProcessRunner({
+			exitCode: 0,
+			stdout: '[ok] ghdl present\n',
+		});
+
+		const result = await runDependencyCheck({
+			profile: 'ghdl',
+			workspaceTrusted: true,
+			workspaceFolderPaths: [workspacePath],
+			env: { PATH: '/usr/bin' },
+			output,
+			statusSink: statuses,
+			runner,
+		});
+
+		assert.strictEqual(result.outcome, 'passed');
+		assert.strictEqual(runner.requests.length, 1);
+		assert.strictEqual(runner.requests[0].executablePath, depsScriptPath);
+		assert.deepStrictEqual(runner.requests[0].args, ['check', 'ghdl']);
+		assert.strictEqual(runner.requests[0].cwd, workspacePath);
+		assert.match(output.text, /\[ok\] ghdl present/);
+		assert.deepStrictEqual(
+			statuses.states(),
+			['checking', 'passing'],
+		);
+	});
+
+	test('reports failed checks without hiding raw output', async () => {
+		const workspacePath = await createTempWorkspace();
+		await createDepsScript(workspacePath);
+		const output = new CapturingOutput();
+		const statuses = new CapturingStatusSink();
+		const errors: string[] = [];
+		const runner = new FakeProcessRunner({
+			exitCode: 2,
+			stderr: '[warn] Missing ghdl\n',
+		});
+
+		const result = await runDependencyCheck({
+			profile: 'ghdl',
+			workspaceTrusted: true,
+			workspaceFolderPaths: [workspacePath],
+			output,
+			statusSink: statuses,
+			runner,
+			showErrorMessage: (message) => errors.push(message),
+		});
+
+		assert.strictEqual(result.outcome, 'failed');
+		assert.strictEqual(result.exitCode, 2);
+		assert.match(output.text, /\[warn\] Missing ghdl/);
+		assert.match(output.text, /failed with exit code 2/);
+		assert.deepStrictEqual(
+			statuses.states(),
+			['checking', 'failing'],
+		);
+		assert.strictEqual(errors.length, 1);
+		assert.match(errors[0], /See the HDL Dev output channel/);
+	});
+
+	test('blocks dependency scripts when workspace trust is missing', async () => {
+		const workspacePath = await createTempWorkspace();
+		await createDepsScript(workspacePath);
+		const output = new CapturingOutput();
+		const statuses = new CapturingStatusSink();
+		const errors: string[] = [];
+		const runner = new FakeProcessRunner({
+			exitCode: 0,
+		});
+
+		const result = await runDependencyCheck({
+			profile: 'docs-assets',
+			workspaceTrusted: false,
+			workspaceFolderPaths: [workspacePath],
+			output,
+			statusSink: statuses,
+			runner,
+			showErrorMessage: (message) => errors.push(message),
+		});
+
+		assert.strictEqual(result.outcome, 'blocked');
+		assert.strictEqual(runner.requests.length, 0);
+		assert.match(output.text, /Workspace trust is required/);
+		assert.deepStrictEqual(statuses.states(), ['failing']);
+		assert.strictEqual(errors.length, 1);
+	});
+
+	test('prefers discovered HDL project dependency scripts over workspace fallback scripts', async () => {
+		const workspacePath = await createTempWorkspace();
+		await createDepsScript(workspacePath);
+		const projectPath = path.join(workspacePath, 'hdl', 'timer');
+		const projectDepsScriptPath = await createDepsScript(projectPath);
+		await writeFixtureFile(path.join(projectPath, 'Makefile'), 'list-tbs:\n');
+		await writeFixtureFile(
+			path.join(projectPath, 'docs', 'waveforms', 'specs', 'timer.json'),
+			'{}\n',
+		);
+
+		const runner = new FakeProcessRunner({
+			exitCode: 0,
+		});
+
+		const result = await runDependencyCheck({
+			profile: 'ghdl',
+			workspaceTrusted: true,
+			workspaceFolderPaths: [workspacePath],
+			output: new CapturingOutput(),
+			runner,
+		});
+
+		assert.strictEqual(result.outcome, 'passed');
+		assert.strictEqual(runner.requests[0].executablePath, projectDepsScriptPath);
+		assert.strictEqual(runner.requests[0].cwd, projectPath);
+	});
+
+	test('formats status item states and command routing', () => {
+		assert.deepStrictEqual(
+			formatDependencyStatusBar({
+				state: 'unknown',
+				message: 'Dependency status unknown',
+			}),
+			{
+				text: '$(beaker) HDL Dev deps',
+				tooltip: 'Dependency status unknown',
+				command: checkGhdlDependenciesCommand,
+			},
+		);
+
+		assert.strictEqual(
+			formatDependencyStatusBar({
+				state: 'checking',
+				message: 'Checking documentation asset dependencies',
+				profile: 'docs-assets',
+			}).command,
+			checkDocsAssetDependenciesCommand,
+		);
+	});
+
+	test('package contributes Dependency Doctor commands', async () => {
+		const packageJsonPath = path.join(__dirname, '..', '..', 'package.json');
+		const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf8')) as {
+			contributes: {
+				commands: Array<{
+					command: string;
+					title: string;
+					category?: string;
+				}>;
+			};
+		};
+
+		assert.deepStrictEqual(
+			packageJson.contributes.commands.map((command) => command.command).sort(),
+			[
+				checkDocsAssetDependenciesCommand,
+				checkGhdlDependenciesCommand,
+			].sort(),
+		);
+		assert.ok(packageJson.contributes.commands.every((command) => command.category === 'HDL Dev'));
+	});
+});
+
+class CapturingOutput implements DependencyOutput {
+	public text = '';
+	public shown = false;
+
+	append(value: string): void {
+		this.text += value;
+	}
+
+	appendLine(value: string): void {
+		this.text += `${value}\n`;
+	}
+
+	show(): void {
+		this.shown = true;
+	}
+}
+
+class CapturingStatusSink {
+	public readonly statuses: DependencyCheckStatus[] = [];
+
+	setStatus(status: DependencyCheckStatus): void {
+		this.statuses.push(status);
+	}
+
+	states(): string[] {
+		return this.statuses.map((status) => status.state);
+	}
+}
+
+class FakeProcessRunner implements DependencyProcessRunner {
+	public readonly requests: DependencyProcessRequest[] = [];
+
+	public constructor(
+		private readonly result: DependencyProcessResult & {
+			readonly stdout?: string;
+			readonly stderr?: string;
+		},
+	) {}
+
+	public async run(
+		request: DependencyProcessRequest,
+		events: DependencyProcessEvents,
+	): Promise<DependencyProcessResult> {
+		this.requests.push(request);
+
+		if (this.result.stdout !== undefined) {
+			events.onStdout(this.result.stdout);
+		}
+
+		if (this.result.stderr !== undefined) {
+			events.onStderr(this.result.stderr);
+		}
+
+		return this.result;
+	}
+}
+
+async function createTempWorkspace(): Promise<string> {
+	const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'hdl-dev-doctor-'));
+	tempRoots.push(tempRoot);
+	return tempRoot;
+}
+
+async function createDepsScript(rootPath: string): Promise<string> {
+	const depsScriptPath = path.join(rootPath, 'scripts', 'deps.sh');
+	await writeFixtureFile(depsScriptPath, '#!/usr/bin/env bash\n');
+	return depsScriptPath;
+}
+
+async function writeFixtureFile(filePath: string, content: string): Promise<void> {
+	await fs.mkdir(path.dirname(filePath), { recursive: true });
+	await fs.writeFile(filePath, content, 'utf8');
+}

--- a/src/test/projectDiscovery.test.ts
+++ b/src/test/projectDiscovery.test.ts
@@ -69,7 +69,7 @@ suite('Project Discovery', () => {
 
 		assert.deepStrictEqual(
 			result.projects.map((project) => project.rootPath),
-			[schematicOnlyProject, waveformOnlyProject].sort(),
+			sortPaths([schematicOnlyProject, waveformOnlyProject]),
 		);
 
 		const waveformProject = result.projects.find((project) => project.rootPath === waveformOnlyProject);
@@ -188,4 +188,8 @@ async function createHdlProject(
 async function writeFixtureFile(filePath: string, content: string): Promise<void> {
 	await fs.mkdir(path.dirname(filePath), { recursive: true });
 	await fs.writeFile(filePath, content, 'utf8');
+}
+
+function sortPaths(paths: readonly string[]): string[] {
+	return [...paths].sort((left, right) => left.localeCompare(right));
 }


### PR DESCRIPTION
## Summary

- contribute Dependency Doctor commands for GHDL and documentation asset checks
- add the HDL Dev output channel and dependency status bar item
- run `scripts/deps.sh check <profile>` through explicit process arguments with trust gating
- preserve raw stdout/stderr for pass and fail cases
- cover pass, fail, workspace-trust blocking, target selection, status formatting, and command contribution behavior
- stabilize project discovery path-ordering assertions exposed by CI temp path casing

Refs #2.

## Local Validation

- `npm run compile`
- `npm run lint`
- `git diff --check`
- `env XDG_RUNTIME_DIR=/tmp/hdl-dev-vscode-runtime npm test`
- `make deps-check-ghdl`

Local VS Code test evidence: `11 passing`, including the six `Dependency Doctor` tests.

## Command/Status Surface Capture

A short capture is attached in the PR comments and issue #2 comments. It shows:

- Command Palette entries for `HDL Dev: Check GHDL Dependencies` and `HDL Dev: Check Documentation Asset Dependencies`
- Status Bar transition from `$(sync~spin) HDL Dev deps` to `$(pass) HDL Dev deps`
- HDL Dev Output channel preserving the raw `scripts/deps.sh check ghdl` transcript

Cached GHDL evidence from `make deps-check-ghdl`:

```text
"/home/cosgroma/workspace/projects/vscode-hdl-dev/scripts/deps.sh" check ghdl
[info] GHDL toolchain root: /home/cosgroma/workspace/projects/vscode-hdl-dev/.cache/hdl-dev-ghdl/installs/v6.0.0
[ok] ghdl: GHDL 6.0.0 (6.0.0.r0.ge589c698c) [Dunoon edition]
[ok] ghwdump: /home/cosgroma/workspace/projects/vscode-hdl-dev/.cache/hdl-dev-ghdl/installs/v6.0.0/bin/ghwdump
[ok] ghwdump supports -H hierarchy output
```

## Remote CI Evidence

- CI: passed - https://github.com/cosgroma/vscode-hdl-dev/actions/runs/24621302523
- Doctor GHDL Smoke: passed - https://github.com/cosgroma/vscode-hdl-dev/actions/runs/24621302521
- Git Flow Policy: passed - https://github.com/cosgroma/vscode-hdl-dev/actions/runs/24621302529