### PR TITLE
Document v0.1 evidence gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # HDL Dev
 
 HDL Dev is a VS Code extension for coordinating HDL project workflows from
-inside the editor. The project is currently an early TypeScript extension
-scaffold with supporting dependency, documentation, CI, and GitHub Pages
-infrastructure in place.
+inside the editor. The project is currently an early TypeScript extension with
+passive HDL project discovery, dependency-check commands, documentation, CI, and
+GitHub Pages infrastructure in place.
 
 The design direction is to keep HDL project scripts as the source of truth and
 wrap them with native VS Code surfaces: commands, Output channels, the Testing
@@ -11,8 +11,8 @@ API, tree views, status items, and focused artifact previews.
 
 ## Features
 
-Current shipped extension behavior is still minimal. The Yeoman baseline command
-is present while the HDL-specific surfaces are being designed and implemented.
+Current shipped extension behavior covers the v0.1 Project Discovery and
+Dependency Doctor milestone.
 
 Feature status:
 
@@ -25,9 +25,9 @@ Feature status:
 - [x] GitHub Actions Doctor smoke workflow with cached GHDL
 - [x] git-flow branch model with branch-direction policy checks
 - [x] MkDocs documentation site deployed to GitHub Pages
-- [ ] HDL project discovery
-- [ ] Dependency Doctor commands and Output channel
-- [ ] dependency status bar item
+- [x] HDL project discovery
+- [x] Dependency Doctor commands and Output channel
+- [x] dependency status bar item
 - [ ] VS Code Testing API testbench discovery and run support
 - [ ] waveform spec tree and SVG generation commands
 - [ ] schematic spec tree and SVG generation commands
@@ -37,11 +37,13 @@ Feature status:
 - [ ] interactive preview surfaces for generated SVGs
 - [ ] packetized-I/O debug session helpers
 
-Planned command names use the `HDL Dev` prefix:
+Shipped command names use the `HDL Dev` prefix:
 
-- `HDL Dev: Discover Project`
 - `HDL Dev: Check GHDL Dependencies`
 - `HDL Dev: Check Documentation Asset Dependencies`
+
+Planned command names:
+
 - `HDL Dev: List Testbenches`
 - `HDL Dev: Run Testbench`
 - `HDL Dev: Generate Waveform SVG`
@@ -83,16 +85,17 @@ https://cosgroma.github.io/vscode-hdl-dev/
 
 ## Extension Settings
 
-No HDL Dev settings are contributed yet.
+HDL Dev contributes these settings:
+
+- `hdlDev.projectRoots`: optional explicit project roots
+- `hdlDev.depsScript`: optional path to `scripts/deps.sh`
+- `hdlDev.toolchainRoot`: optional `GHDL_TOOLCHAIN_ROOT`
 
 Planned settings:
 
-- `hdlDev.projectRoots`: optional explicit project roots
 - `hdlDev.makeExecutable`: make executable path, defaulting to `make`
 - `hdlDev.defaultStopTime`: default GHDL stop time, for example `500us`
 - `hdlDev.defaultWaveFormat`: default wave format, initially `ghw`
-- `hdlDev.depsScript`: optional path to `scripts/deps.sh`
-- `hdlDev.toolchainRoot`: optional `GHDL_TOOLCHAIN_ROOT`
 
 ## Repository Workflow
 
@@ -141,11 +144,12 @@ generation.
 
 ## Known Issues
 
-- The extension UI still contains the Yeoman `Hello World` command.
-- No HDL-specific VS Code commands are implemented yet.
 - The local GHDL bootstrap path is Linux x86_64 only.
-- Dependency checks are human-readable shell output; JSON output is planned for
-  more reliable extension integration.
+- Dependency Doctor uses coarse pass/fail process status and human-readable
+  shell output; JSON output is planned for more reliable extension integration.
+- Dependency Doctor commands are blocked until the workspace is trusted.
+- Testbench running, spec trees, artifact navigation, previews, schemas, and
+  packetized-I/O debug helpers are planned but not implemented yet.
 - Waveform and schematic generation are documented as design targets but are not
   implemented in the extension yet.
 
@@ -157,6 +161,8 @@ Initial scaffold and project infrastructure:
 
 - TypeScript VS Code extension baseline
 - repo-owned dependency scripts and Make targets
+- passive HDL project discovery
+- Dependency Doctor commands, Output channel, and status item
 - cached GHDL Doctor smoke workflow
 - git-flow branch model
 - MkDocs GitHub Pages deployment
@@ -167,6 +173,8 @@ Design notes live under `docs/` and are published through MkDocs:
 
 - [VS Code Workbench References](docs/references/vscode-workbench-surfaces.md)
 - [GEnCor Integration Notes](docs/integrations/gencor.md)
+- [v0.1 Project Discovery And Dependency Doctor](docs/workflows/v0.1-project-discovery-and-doctor.md)
+- [Project Discovery](docs/design/project-discovery.md)
 - [Initial Extension Design](docs/design/initial-extension-design.md)
 - [MVP Roadmap](docs/design/mvp-roadmap.md)
 - [CI GHDL Cache Strategy](docs/design/ci-ghdl-cache.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,9 @@ repo's own extension-facing command-line workflow.
 - [GEnCor Integration Notes](integrations/gencor.md) summarizes the GEnCor flows
   we plan to adapt: dependency checks, GHDL testbench runs, waveform SVG
   generation, schematic SVG generation, and packetized-I/O debug helpers.
+- [v0.1 Project Discovery And Dependency Doctor](workflows/v0.1-project-discovery-and-doctor.md)
+  describes the shipped discovery and dependency-check workflow, expected
+  output, trust behavior, and evidence coverage.
 - [Initial Extension Design](design/initial-extension-design.md) describes the
   proposed feature areas, VS Code surfaces, and implementation boundaries.
 - [Project Discovery](design/project-discovery.md) documents the passive

--- a/docs/workflows/v0.1-project-discovery-and-doctor.md
+++ b/docs/workflows/v0.1-project-discovery-and-doctor.md
@@ -1,0 +1,163 @@
+# v0.1 Project Discovery And Dependency Doctor
+
+The v0.1 workflow gives HDL Dev enough project context to run dependency
+checks from VS Code without replacing repo-local HDL scripts.
+
+## What Ships
+
+v0.1 includes:
+
+- passive HDL project discovery
+- `HDL Dev: Check GHDL Dependencies`
+- `HDL Dev: Check Documentation Asset Dependencies`
+- an `HDL Dev` Output channel
+- one dependency status bar item
+
+## Project Discovery
+
+Discovery is a passive file scan. It does not run Make, shell scripts, Python,
+GHDL, Yosys, or `netlistsvg`.
+
+HDL Dev detects a project when a candidate root has:
+
+- `Makefile`
+- at least one spec directory:
+  - `docs/waveforms/specs`
+  - `docs/schematics/specs`
+
+The discovery model records paths for the Makefile, dependency script, spec
+directories, build directories, and generated artifact directories. Missing
+optional paths are reported as capabilities instead of failing discovery.
+
+## Dependency Doctor Commands
+
+Run Dependency Doctor from the Command Palette:
+
+- `HDL Dev: Check GHDL Dependencies`
+- `HDL Dev: Check Documentation Asset Dependencies`
+
+The commands look for `scripts/deps.sh` in discovered HDL projects first, then
+fall back to workspace folders. The script path can be changed with
+`hdlDev.depsScript`.
+
+The command process uses explicit argument arrays:
+
+```text
+scripts/deps.sh check ghdl
+scripts/deps.sh check docs-assets
+```
+
+HDL Dev does not build a shell command string for these checks.
+
+## Workspace Trust
+
+Discovery remains available before workspace trust because it only reads the
+filesystem. Dependency Doctor is different: it executes workspace scripts and
+therefore requires a trusted workspace.
+
+When the workspace is not trusted, HDL Dev blocks the script run, writes the
+reason to the Output channel, and keeps the raw failure path visible to the
+user.
+
+## Settings
+
+The v0.1 settings are:
+
+- `hdlDev.projectRoots`: optional explicit HDL project roots. Relative paths
+  resolve under each workspace folder.
+- `hdlDev.depsScript`: dependency script path, defaulting to `scripts/deps.sh`.
+- `hdlDev.toolchainRoot`: optional GHDL toolchain root. When set, HDL Dev passes
+  it as `GHDL_TOOLCHAIN_ROOT` and prepends its `bin` directory to `PATH`.
+
+## Expected Output
+
+The dependency status item starts as:
+
+```text
+$(beaker) HDL Dev deps
+```
+
+During a GHDL check it changes to:
+
+```text
+$(sync~spin) HDL Dev deps | Checking GHDL dependencies
+```
+
+On success it changes to:
+
+```text
+$(pass) HDL Dev deps | GHDL dependencies passed
+```
+
+The `HDL Dev` Output channel preserves the command context and raw script
+output:
+
+```text
+[HDL Dev] Running HDL Dev: Check GHDL Dependencies
+[HDL Dev] Profile: ghdl
+[HDL Dev] Target root: /path/to/workspace
+[HDL Dev] Target source: workspaceFolder
+[HDL Dev] Executable: /path/to/workspace/scripts/deps.sh
+[HDL Dev] Arguments: ["check","ghdl"]
+[HDL Dev] Working directory: /path/to/workspace
+[HDL Dev] Environment:
+  GHDL_TOOLCHAIN_ROOT=<unset>
+  HDL_DEV_GHDL_ROOT=<unset>
+  HDL_DEV_GHDL_BASE=<unset>
+  HDL_DEV_GHDL_TAG=<unset>
+
+[info] GHDL toolchain root: /path/to/.cache/hdl-dev-ghdl/installs/v6.0.0
+[ok] ghdl: GHDL 6.0.0 (6.0.0.r0.ge589c698c) [Dunoon edition]
+[ok] ghwdump: /path/to/.cache/hdl-dev-ghdl/installs/v6.0.0/bin/ghwdump
+[ok] ghwdump supports -H hierarchy output
+
+[ok] GHDL dependencies passed
+```
+
+Failed checks keep stdout and stderr in the same Output channel and show an
+actionable VS Code error message pointing users back to that raw output.
+
+## Developer Evidence
+
+Automated coverage lives in:
+
+- `src/test/projectDiscovery.test.ts`
+- `src/test/dependencyDoctor.test.ts`
+
+The discovery tests cover:
+
+- one discovered project
+- multi-root workspaces
+- configured roots
+- partial layouts that should not be projects
+- passive discovery state
+
+The Dependency Doctor tests cover:
+
+- passing dependency checks
+- failing dependency checks
+- raw output preservation
+- workspace trust blocking
+- discovered-project target selection
+- status item formatting
+- command contribution metadata
+
+Relevant local checks:
+
+```bash
+npm run compile
+npm run lint
+env XDG_RUNTIME_DIR=/tmp/hdl-dev-vscode-runtime npm test
+make deps-check-ghdl
+make docs-build
+```
+
+## Known Limitations
+
+- The GHDL bootstrap path is Linux x86_64 only.
+- Dependency Doctor currently consumes human-readable script output and process
+  exit status. Machine-readable script output is planned when the extension
+  needs stronger introspection.
+- Testbench discovery and execution are planned for the next milestone.
+- Specs trees, artifact navigation, JSON schemas, previews, and packetized-I/O
+  debug sessions remain future work.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,6 +15,8 @@ nav:
       - VS Code Workbench Surfaces: references/vscode-workbench-surfaces.md
   - Integrations:
       - GEnCor: integrations/gencor.md
+  - Workflows:
+      - v0.1 Project Discovery And Dependency Doctor: workflows/v0.1-project-discovery-and-doctor.md
   - Design:
       - Project Discovery: design/project-discovery.md
       - Initial Extension Design: design/initial-extension-design.md


### PR DESCRIPTION
## Summary

- update the README feature checklist for the shipped v0.1 Project Discovery and Dependency Doctor surfaces
- add a MkDocs workflow page for v0.1 discovery, dependency checks, trust behavior, expected output, tests, and known limitations
- link the v0.1 workflow page from the docs index and navigation

Refs #3.

## Local Validation

- `npm run compile`
- `npm run lint`
- `git diff --check`
- `make docs-build`
- `env XDG_RUNTIME_DIR=/tmp/hdl-dev-vscode-runtime npm test`
- `make deps-check-ghdl`

Local VS Code test evidence: `11 passing`, including Project Discovery and Dependency Doctor coverage.

Docs build evidence:

```text
"mkdocs" build --strict --site-dir "site"
INFO    -  Cleaning site directory
INFO    -  Building documentation to directory: /home/cosgroma/workspace/projects/vscode-hdl-dev/site
INFO    -  Documentation built in 0.94 seconds
```

Cached GHDL evidence:

```text
"/home/cosgroma/workspace/projects/vscode-hdl-dev/scripts/deps.sh" check ghdl
[info] GHDL toolchain root: /home/cosgroma/workspace/projects/vscode-hdl-dev/.cache/hdl-dev-ghdl/installs/v6.0.0
[ok] ghdl: GHDL 6.0.0 (6.0.0.r0.ge589c698c) [Dunoon edition]
[ok] ghwdump: /home/cosgroma/workspace/projects/vscode-hdl-dev/.cache/hdl-dev-ghdl/installs/v6.0.0/bin/ghwdump
[ok] ghwdump supports -H hierarchy output
```

## Remote Evidence

- CI: passed - https://github.com/cosgroma/vscode-hdl-dev/actions/runs/24621632909
- Pages build: passed - https://github.com/cosgroma/vscode-hdl-dev/actions/runs/24621632913
- Git Flow Policy: passed - https://github.com/cosgroma/vscode-hdl-dev/actions/runs/24621632911
- Doctor GHDL Smoke: passed - https://github.com/cosgroma/vscode-hdl-dev/actions/runs/24621643189

## v0.1 Evidence Links

- Project Discovery implementation: #19
- Dependency Doctor implementation: #20
- Project Discovery issue closed/accepted: #1
- Dependency Doctor issue closed/accepted: #2
- Command/status surface capture: https://github.com/cosgroma/vscode-hdl-dev/issues/2#issuecomment-4275216627