### PR TITLE
Add Make-backed testbench discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 HDL Dev is a VS Code extension for coordinating HDL project workflows from
 inside the editor. The project is currently an early TypeScript extension with
-passive HDL project discovery, dependency-check commands, documentation, CI, and
-GitHub Pages infrastructure in place.
+passive HDL project discovery, dependency-check commands, testbench discovery,
+documentation, CI, and GitHub Pages infrastructure in place.
 
 The design direction is to keep HDL project scripts as the source of truth and
 wrap them with native VS Code surfaces: commands, Output channels, the Testing
@@ -12,7 +12,7 @@ API, tree views, status items, and focused artifact previews.
 ## Features
 
 Current shipped extension behavior covers the v0.1 Project Discovery and
-Dependency Doctor milestone.
+Dependency Doctor milestone plus the first v0.2 testbench discovery slice.
 
 Feature status:
 
@@ -28,7 +28,8 @@ Feature status:
 - [x] HDL project discovery
 - [x] Dependency Doctor commands and Output channel
 - [x] dependency status bar item
-- [ ] VS Code Testing API testbench discovery and run support
+- [x] VS Code Testing API testbench discovery
+- [ ] VS Code Testing API testbench run support
 - [ ] waveform spec tree and SVG generation commands
 - [ ] schematic spec tree and SVG generation commands
 - [ ] generated artifact explorer
@@ -89,11 +90,11 @@ HDL Dev contributes these settings:
 
 - `hdlDev.projectRoots`: optional explicit project roots
 - `hdlDev.depsScript`: optional path to `scripts/deps.sh`
+- `hdlDev.makeExecutable`: make executable path, defaulting to `make`
 - `hdlDev.toolchainRoot`: optional `GHDL_TOOLCHAIN_ROOT`
 
 Planned settings:
 
-- `hdlDev.makeExecutable`: make executable path, defaulting to `make`
 - `hdlDev.defaultStopTime`: default GHDL stop time, for example `500us`
 - `hdlDev.defaultWaveFormat`: default wave format, initially `ghw`
 
@@ -174,6 +175,7 @@ Design notes live under `docs/` and are published through MkDocs:
 - [VS Code Workbench References](docs/references/vscode-workbench-surfaces.md)
 - [GEnCor Integration Notes](docs/integrations/gencor.md)
 - [v0.1 Project Discovery And Dependency Doctor](docs/workflows/v0.1-project-discovery-and-doctor.md)
+- [v0.2 Testbench Discovery](docs/workflows/v0.2-testbench-discovery.md)
 - [Project Discovery](docs/design/project-discovery.md)
 - [Initial Extension Design](docs/design/initial-extension-design.md)
 - [MVP Roadmap](docs/design/mvp-roadmap.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,9 @@ repo's own extension-facing command-line workflow.
 - [v0.1 Project Discovery And Dependency Doctor](workflows/v0.1-project-discovery-and-doctor.md)
   describes the shipped discovery and dependency-check workflow, expected
   output, trust behavior, and evidence coverage.
+- [v0.2 Testbench Discovery](workflows/v0.2-testbench-discovery.md) describes
+  the `make list-tbs` discovery contract, Testing API surface, trust behavior,
+  and managed Makefile pattern.
 - [Initial Extension Design](design/initial-extension-design.md) describes the
   proposed feature areas, VS Code surfaces, and implementation boundaries.
 - [Project Discovery](design/project-discovery.md) documents the passive

--- a/docs/workflows/v0.2-testbench-discovery.md
+++ b/docs/workflows/v0.2-testbench-discovery.md
@@ -1,0 +1,76 @@
+# v0.2 Testbench Discovery
+
+HDL Dev discovers GHDL testbenches by asking each detected HDL project to list
+its own testbench names. The project Makefile remains the source of truth.
+
+## Make Contract
+
+The extension invokes this command from each project root:
+
+```bash
+make list-tbs
+```
+
+The command should write one testbench name per line to standard output:
+
+```text
+timer_tb
+uart_tb
+fifo_tb
+```
+
+Blank lines and comment lines beginning with `#` are ignored. Duplicate names
+are collapsed while preserving first-seen order. Raw standard output and
+standard error are still appended to the HDL Dev Output channel for diagnostics.
+
+## Managed Makefile Pattern
+
+Projects can keep discovery flexible by aggregating testbench names in a
+project-owned variable and using small Make recipes around it:
+
+```make
+HDL_DEV_TESTBENCHES := timer_tb uart_tb fifo_tb
+
+.PHONY: list-tbs
+list-tbs:
+	@printf '%s\n' $(HDL_DEV_TESTBENCHES)
+```
+
+This keeps the extension-facing contract stable without moving build logic into
+the extension. Larger projects can later include shared Make fragments such as
+`scripts/hdl-dev-ghdl.mk`, but those fragments should still live in the project
+repository and expose the same `list-tbs` target.
+
+## VS Code Surface
+
+The extension registers an `HDL Dev Testbenches` TestController. Testbench
+discovery runs when VS Code resolves or refreshes the test tree, not during
+extension activation.
+
+Each discovered project is represented as a separate test namespace. Testbench
+item IDs include the project root path, so two roots can both expose a
+`timer_tb` without colliding.
+
+## Trust And Cancellation
+
+`make list-tbs` is a workspace command. Discovery is blocked until the workspace
+is trusted.
+
+Refresh cancellation is forwarded to the spawned Make process. Slow discovery
+is reported through the discovery state model while allowing Make to complete.
+
+## Settings
+
+- `hdlDev.projectRoots`: optional explicit HDL project roots. Relative paths
+  resolve under each workspace folder.
+- `hdlDev.makeExecutable`: Make executable path, defaulting to `make`.
+- `hdlDev.toolchainRoot`: optional GHDL toolchain root. When set, HDL Dev passes
+  it as `GHDL_TOOLCHAIN_ROOT` and prepends its `bin` directory to `PATH`.
+
+## Current Limits
+
+- Discovery is line-oriented; Makefiles should keep `list-tbs` output concise
+  and machine-facing.
+- Running testbenches is not implemented yet.
+- The extension does not generate or inject managed Makefiles. Shared recipe
+  templates should be added as project-local files when needed.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,6 +17,7 @@ nav:
       - GEnCor: integrations/gencor.md
   - Workflows:
       - v0.1 Project Discovery And Dependency Doctor: workflows/v0.1-project-discovery-and-doctor.md
+      - v0.2 Testbench Discovery: workflows/v0.2-testbench-discovery.md
   - Design:
       - Project Discovery: design/project-discovery.md
       - Initial Extension Design: design/initial-extension-design.md

--- a/package.json
+++ b/package.json
@@ -44,6 +44,11 @@
           "default": "scripts/deps.sh",
           "description": "Path to the dependency script to run from a discovered project or workspace folder."
         },
+        "hdlDev.makeExecutable": {
+          "type": "string",
+          "default": "make",
+          "description": "Make executable used for HDL project testbench discovery and runs."
+        },
         "hdlDev.toolchainRoot": {
           "type": "string",
           "default": "",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,6 +9,7 @@ import {
 	type DependencyCheckProfile,
 	type DependencyCheckStatus,
 } from './doctor/dependencyDoctor';
+import { registerTestbenchController } from './testbench/testbenchController';
 
 export function activate(context: vscode.ExtensionContext) {
 	const outputChannel = vscode.window.createOutputChannel('HDL Dev');
@@ -24,6 +25,7 @@ export function activate(context: vscode.ExtensionContext) {
 	};
 
 	statusSink.setStatus(createUnknownDependencyStatus());
+	registerTestbenchController(context, outputChannel);
 
 	const runDoctorCommand = async (profile: DependencyCheckProfile): Promise<void> => {
 		const configuration = vscode.workspace.getConfiguration('hdlDev');

--- a/src/test/testbenchDiscovery.test.ts
+++ b/src/test/testbenchDiscovery.test.ts
@@ -1,0 +1,341 @@
+import * as assert from 'node:assert';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import {
+	createTestbenchItemId,
+	nodeTestbenchProcessRunner,
+	parseTestbenchList,
+	TestbenchDiscoveryService,
+	type TestbenchDiscoveryOutput,
+	type TestbenchDiscoveryStateSink,
+	type TestbenchProcessEvents,
+	type TestbenchProcessRequest,
+	type TestbenchProcessResult,
+	type TestbenchProcessRunner,
+	type TestbenchProjectState,
+} from '../testbench/testbenchDiscovery';
+
+const tempRoots: string[] = [];
+
+suite('Testbench Discovery', () => {
+	teardown(async () => {
+		await Promise.all(tempRoots.splice(0).map(async (tempRoot) => {
+			await fs.rm(tempRoot, { recursive: true, force: true });
+		}));
+	});
+
+	test('parses line-oriented testbench names while preserving order', () => {
+		assert.deepStrictEqual(
+			parseTestbenchList([
+				'',
+				'# managed Makefile comment',
+				' timer_tb ',
+				'uart_tb',
+				'timer_tb',
+				'fifo_tb',
+				'',
+			].join('\n')),
+			['timer_tb', 'uart_tb', 'fifo_tb'],
+		);
+	});
+
+	test('runs make list-tbs with explicit process arguments', async () => {
+		const workspacePath = await createTempWorkspace();
+		const projectPath = path.join(workspacePath, 'pcores', 'timer');
+		await createHdlProject(projectPath);
+		const output = new CapturingOutput();
+		const runner = new FakeProcessRunner({
+			exitCode: 0,
+			stdout: 'timer_tb\nuart_tb\n',
+		});
+
+		const result = await new TestbenchDiscoveryService().discoverWorkspace({
+			workspaceTrusted: true,
+			workspaceFolderPaths: [workspacePath],
+			env: { PATH: '/usr/bin' },
+			output,
+			runner,
+		});
+
+		assert.strictEqual(result.outcome, 'discovered');
+		assert.strictEqual(runner.requests.length, 1);
+		assert.strictEqual(runner.requests[0].executablePath, 'make');
+		assert.deepStrictEqual(runner.requests[0].args, ['list-tbs']);
+		assert.strictEqual(runner.requests[0].cwd, projectPath);
+		assert.deepStrictEqual(
+			result.projects[0].testbenches.map((testbench) => testbench.name),
+			['timer_tb', 'uart_tb'],
+		);
+		assert.strictEqual(result.projects[0].rawOutput.stdout, 'timer_tb\nuart_tb\n');
+		assert.match(output.text, /timer_tb/);
+	});
+
+	test('keeps same-named testbenches in separate project namespaces', async () => {
+		const workspacePath = await createTempWorkspace();
+		const alphaProjectPath = path.join(workspacePath, 'alpha', 'timer');
+		const betaProjectPath = path.join(workspacePath, 'beta', 'timer');
+		await createHdlProject(alphaProjectPath);
+		await createHdlProject(betaProjectPath);
+		const runner = new FakeProcessRunner((request) => ({
+			exitCode: 0,
+			stdout: request.cwd === alphaProjectPath ? 'timer_tb\n' : 'timer_tb\nfifo_tb\n',
+		}));
+
+		const result = await new TestbenchDiscoveryService().discoverWorkspace({
+			workspaceTrusted: true,
+			workspaceFolderPaths: [workspacePath],
+			output: new CapturingOutput(),
+			runner,
+		});
+
+		assert.strictEqual(result.outcome, 'discovered');
+		assert.strictEqual(result.projects.length, 2);
+		const testbenchIds = result.projects.flatMap((project) => (
+			project.testbenches.map((testbench) => testbench.id)
+		));
+		assert.strictEqual(new Set(testbenchIds).size, 3);
+		assert.ok(testbenchIds.includes(createTestbenchItemId(alphaProjectPath, 'timer_tb')));
+		assert.ok(testbenchIds.includes(createTestbenchItemId(betaProjectPath, 'timer_tb')));
+		assert.deepStrictEqual(
+			result.projects.map((project) => project.project.rootPath),
+			[alphaProjectPath, betaProjectPath].sort(),
+		);
+	});
+
+	test('reports empty and failed discovery without throwing', async () => {
+		const workspacePath = await createTempWorkspace();
+		const emptyProjectPath = path.join(workspacePath, 'empty');
+		const failedProjectPath = path.join(workspacePath, 'failed');
+		await createHdlProject(emptyProjectPath);
+		await createHdlProject(failedProjectPath);
+		const output = new CapturingOutput();
+		const runner = new FakeProcessRunner((request) => {
+			if (request.cwd === failedProjectPath) {
+				return {
+					exitCode: 2,
+					stderr: '[error] failed list\n',
+				};
+			}
+
+			return {
+				exitCode: 0,
+				stdout: '# no testbenches\n\n',
+			};
+		});
+
+		const result = await new TestbenchDiscoveryService().discoverWorkspace({
+			workspaceTrusted: true,
+			workspaceFolderPaths: [workspacePath],
+			output,
+			runner,
+		});
+
+		assert.strictEqual(result.outcome, 'failed');
+		assert.deepStrictEqual(
+			result.projects.map((project) => project.outcome).sort(),
+			['empty', 'failed'],
+		);
+		assert.match(output.text, /No testbenches were reported/);
+		assert.match(output.text, /\[error\] failed list/);
+	});
+
+	test('cancels discovery before invoking Make for a project', async () => {
+		const workspacePath = await createTempWorkspace();
+		await createHdlProject(path.join(workspacePath, 'pcores', 'timer'));
+		const abortController = new AbortController();
+		abortController.abort();
+		const runner = new FakeProcessRunner({
+			exitCode: 0,
+			stdout: 'timer_tb\n',
+		});
+
+		const result = await new TestbenchDiscoveryService().discoverWorkspace({
+			workspaceTrusted: true,
+			workspaceFolderPaths: [workspacePath],
+			output: new CapturingOutput(),
+			runner,
+			cancellationSignal: abortController.signal,
+		});
+
+		assert.strictEqual(result.outcome, 'cancelled');
+		assert.strictEqual(result.projects[0].outcome, 'cancelled');
+		assert.strictEqual(runner.requests.length, 0);
+	});
+
+	test('reports slow discovery state while preserving the final result', async () => {
+		const workspacePath = await createTempWorkspace();
+		const projectPath = path.join(workspacePath, 'pcores', 'timer');
+		await createHdlProject(projectPath);
+		const states = new CapturingStateSink();
+		const runner = new FakeProcessRunner({
+			exitCode: 0,
+			stdout: 'timer_tb\n',
+			delayMs: 20,
+		});
+
+		const result = await new TestbenchDiscoveryService().discoverWorkspace({
+			workspaceTrusted: true,
+			workspaceFolderPaths: [workspacePath],
+			output: new CapturingOutput(),
+			stateSink: states,
+			runner,
+			slowThresholdMs: 1,
+		});
+
+		assert.strictEqual(result.outcome, 'discovered');
+		assert.deepStrictEqual(
+			states.states(),
+			['discovering', 'slow', 'discovered'],
+		);
+	});
+
+	test('reuses in-flight discovery for the same project root', async () => {
+		const workspacePath = await createTempWorkspace();
+		await createHdlProject(path.join(workspacePath, 'pcores', 'timer'));
+		const service = new TestbenchDiscoveryService();
+		const runner = new FakeProcessRunner({
+			exitCode: 0,
+			stdout: 'timer_tb\n',
+			delayMs: 20,
+		});
+		const options = {
+			workspaceTrusted: true,
+			workspaceFolderPaths: [workspacePath],
+			output: new CapturingOutput(),
+			runner,
+		};
+
+		const [firstResult, secondResult] = await Promise.all([
+			service.discoverWorkspace(options),
+			service.discoverWorkspace(options),
+		]);
+
+		assert.strictEqual(runner.requests.length, 1);
+		assert.strictEqual(firstResult.outcome, 'discovered');
+		assert.strictEqual(secondResult.outcome, 'discovered');
+		assert.strictEqual(firstResult.projects[0], secondResult.projects[0]);
+	});
+
+	test('discovers testbenches from a managed-style fixture Makefile', async () => {
+		const workspacePath = await createTempWorkspace();
+		const projectPath = path.join(workspacePath, 'pcores', 'timer');
+		await createHdlProject(projectPath, [
+			'HDL_DEV_TESTBENCHES := timer_tb uart_tb fifo_tb',
+			'',
+			'.PHONY: list-tbs',
+			'list-tbs:',
+			"\t@printf '%s\\n' $(HDL_DEV_TESTBENCHES)",
+			'',
+		].join('\n'));
+
+		const result = await new TestbenchDiscoveryService().discoverWorkspace({
+			workspaceTrusted: true,
+			workspaceFolderPaths: [workspacePath],
+			output: new CapturingOutput(),
+			runner: nodeTestbenchProcessRunner,
+		});
+
+		assert.strictEqual(result.outcome, 'discovered');
+		assert.deepStrictEqual(
+			result.projects[0].testbenches.map((testbench) => testbench.name),
+			['timer_tb', 'uart_tb', 'fifo_tb'],
+		);
+	});
+});
+
+class CapturingOutput implements TestbenchDiscoveryOutput {
+	public text = '';
+	public shown = false;
+
+	append(value: string): void {
+		this.text += value;
+	}
+
+	appendLine(value: string): void {
+		this.text += `${value}\n`;
+	}
+
+	show(): void {
+		this.shown = true;
+	}
+}
+
+class CapturingStateSink implements TestbenchDiscoveryStateSink {
+	private readonly projectStates: TestbenchProjectState[] = [];
+
+	setProjectState(state: TestbenchProjectState): void {
+		this.projectStates.push(state);
+	}
+
+	states(): string[] {
+		return this.projectStates.map((state) => state.state);
+	}
+}
+
+type FakeProcessResponse = TestbenchProcessResult & {
+	readonly stdout?: string;
+	readonly stderr?: string;
+	readonly delayMs?: number;
+};
+
+type FakeProcessHandler = (request: TestbenchProcessRequest) => FakeProcessResponse | Promise<FakeProcessResponse>;
+
+class FakeProcessRunner implements TestbenchProcessRunner {
+	public readonly requests: TestbenchProcessRequest[] = [];
+	private readonly handler: FakeProcessHandler;
+
+	public constructor(response: FakeProcessResponse | FakeProcessHandler) {
+		this.handler = typeof response === 'function' ? response : () => response;
+	}
+
+	public async run(
+		request: TestbenchProcessRequest,
+		events: TestbenchProcessEvents,
+	): Promise<TestbenchProcessResult> {
+		this.requests.push(request);
+		const response = await this.handler(request);
+
+		if (response.delayMs !== undefined) {
+			await new Promise((resolve) => setTimeout(resolve, response.delayMs));
+		}
+
+		if (response.stdout !== undefined) {
+			events.onStdout(response.stdout);
+		}
+
+		if (response.stderr !== undefined) {
+			events.onStderr(response.stderr);
+		}
+
+		return response;
+	}
+}
+
+async function createTempWorkspace(): Promise<string> {
+	const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'hdl-dev-testbench-'));
+	tempRoots.push(tempRoot);
+	return tempRoot;
+}
+
+async function createHdlProject(
+	projectPath: string,
+	makefileContent = [
+		'.PHONY: list-tbs',
+		'list-tbs:',
+		'\t@printf "timer_tb\\n"',
+		'',
+	].join('\n'),
+): Promise<void> {
+	await writeFixtureFile(path.join(projectPath, 'Makefile'), makefileContent);
+	await writeFixtureFile(
+		path.join(projectPath, 'docs', 'waveforms', 'specs', 'timer.json'),
+		'{}\n',
+	);
+}
+
+async function writeFixtureFile(filePath: string, content: string): Promise<void> {
+	await fs.mkdir(path.dirname(filePath), { recursive: true });
+	await fs.writeFile(filePath, content, 'utf8');
+}

--- a/src/testbench/testbenchController.ts
+++ b/src/testbench/testbenchController.ts
@@ -1,0 +1,108 @@
+import * as path from 'node:path';
+
+import * as vscode from 'vscode';
+
+import {
+	createTestbenchItemId,
+	TestbenchDiscoveryService,
+	type TestbenchDiscoveryResult,
+	type TestbenchProjectDiscoveryResult,
+} from './testbenchDiscovery';
+
+export const testbenchControllerId = 'vscode-hdl-dev.testbenches';
+
+export function registerTestbenchController(
+	context: vscode.ExtensionContext,
+	outputChannel: vscode.OutputChannel,
+): void {
+	const controller = vscode.tests.createTestController(
+		testbenchControllerId,
+		'HDL Dev Testbenches',
+	);
+	const discoveryService = new TestbenchDiscoveryService();
+
+	const refresh = async (token?: vscode.CancellationToken): Promise<void> => {
+		const configuration = vscode.workspace.getConfiguration('hdlDev');
+		const configuredRootPaths = configuration.get<readonly string[]>('projectRoots', []);
+		const makeExecutable = configuration.get<string>('makeExecutable', 'make');
+		const toolchainRoot = configuration.get<string>('toolchainRoot', '').trim();
+		const abortController = new AbortController();
+		const cancellationSubscription = token?.onCancellationRequested(() => {
+			abortController.abort();
+		});
+
+		if (token?.isCancellationRequested === true) {
+			abortController.abort();
+		}
+
+		try {
+			const result = await discoveryService.discoverWorkspace({
+				workspaceTrusted: vscode.workspace.isTrusted,
+				workspaceFolderPaths: vscode.workspace.workspaceFolders?.map((folder) => folder.uri.fsPath) ?? [],
+				configuredRootPaths,
+				makeExecutable,
+				environmentOverrides: toolchainRoot === '' ? {} : { GHDL_TOOLCHAIN_ROOT: toolchainRoot },
+				output: outputChannel,
+				cancellationSignal: abortController.signal,
+			});
+			replaceTestItems(controller, result);
+		} finally {
+			cancellationSubscription?.dispose();
+		}
+	};
+
+	controller.refreshHandler = refresh;
+	controller.resolveHandler = async (item) => {
+		if (item === undefined) {
+			await refresh();
+		}
+	};
+
+	context.subscriptions.push(controller);
+}
+
+function replaceTestItems(
+	controller: vscode.TestController,
+	result: TestbenchDiscoveryResult,
+): void {
+	controller.items.replace(
+		result.projects.map((projectResult) => createProjectTestItem(controller, projectResult)),
+	);
+}
+
+function createProjectTestItem(
+	controller: vscode.TestController,
+	projectResult: TestbenchProjectDiscoveryResult,
+): vscode.TestItem {
+	const project = projectResult.project;
+	const projectItem = controller.createTestItem(
+		createProjectItemId(project.rootPath),
+		path.basename(project.rootPath),
+		vscode.Uri.file(project.rootPath),
+	);
+	projectItem.description = project.rootPath;
+	projectItem.canResolveChildren = false;
+
+	if (projectResult.outcome === 'failed' || projectResult.outcome === 'cancelled') {
+		projectItem.error = projectResult.message;
+	}
+
+	projectItem.children.replace(
+		projectResult.testbenches.map((testbench) => {
+			const testbenchItem = controller.createTestItem(
+				createTestbenchItemId(testbench.projectRootPath, testbench.name),
+				testbench.name,
+				vscode.Uri.file(project.makefilePath),
+			);
+			testbenchItem.canResolveChildren = false;
+			testbenchItem.description = project.rootPath;
+			return testbenchItem;
+		}),
+	);
+
+	return projectItem;
+}
+
+function createProjectItemId(projectRootPath: string): string {
+	return `project::${path.resolve(projectRootPath)}`;
+}

--- a/src/testbench/testbenchDiscovery.ts
+++ b/src/testbench/testbenchDiscovery.ts
@@ -1,0 +1,532 @@
+import { spawn } from 'node:child_process';
+import * as path from 'node:path';
+
+import {
+	discoverHdlProjects,
+	type HdlProjectModel,
+} from '../discovery/projectDiscovery';
+
+export const testbenchDiscoveryExecution = {
+	mode: 'make-list-tbs',
+	executedWorkspaceCommands: true,
+	requiresWorkspaceTrust: true,
+} as const;
+
+export type TestbenchDiscoveryOutcome =
+	| 'discovered'
+	| 'empty'
+	| 'failed'
+	| 'blocked'
+	| 'noProjects'
+	| 'cancelled';
+
+export type TestbenchProjectDiscoveryState =
+	| 'discovering'
+	| 'slow'
+	| 'discovered'
+	| 'empty'
+	| 'failed'
+	| 'cancelled';
+
+export interface TestbenchDiscoveryOutput {
+	append(value: string): void;
+	appendLine(value: string): void;
+	show(preserveFocus?: boolean): void;
+}
+
+export interface TestbenchDiscoveryStateSink {
+	setProjectState(state: TestbenchProjectState): void;
+}
+
+export interface TestbenchProjectState {
+	readonly projectRootPath: string;
+	readonly state: TestbenchProjectDiscoveryState;
+	readonly message: string;
+}
+
+export interface TestbenchProcessRequest {
+	readonly executablePath: string;
+	readonly args: readonly string[];
+	readonly cwd: string;
+	readonly env: NodeJS.ProcessEnv;
+	readonly signal?: AbortSignal;
+}
+
+export interface TestbenchProcessEvents {
+	readonly onStdout: (chunk: string) => void;
+	readonly onStderr: (chunk: string) => void;
+}
+
+export interface TestbenchProcessResult {
+	readonly exitCode: number;
+	readonly signal?: NodeJS.Signals;
+}
+
+export interface TestbenchProcessRunner {
+	run(
+		request: TestbenchProcessRequest,
+		events: TestbenchProcessEvents,
+	): Promise<TestbenchProcessResult>;
+}
+
+export interface TestbenchDiscoveryOptions {
+	readonly workspaceTrusted: boolean;
+	readonly workspaceFolderPaths: readonly string[];
+	readonly configuredRootPaths?: readonly string[];
+	readonly makeExecutable?: string;
+	readonly env?: NodeJS.ProcessEnv;
+	readonly environmentOverrides?: NodeJS.ProcessEnv;
+	readonly output: TestbenchDiscoveryOutput;
+	readonly stateSink?: TestbenchDiscoveryStateSink;
+	readonly runner?: TestbenchProcessRunner;
+	readonly cancellationSignal?: AbortSignal;
+	readonly slowThresholdMs?: number;
+}
+
+export interface DiscoveredTestbench {
+	readonly id: string;
+	readonly name: string;
+	readonly projectRootPath: string;
+	readonly projectNamespace: string;
+}
+
+export interface TestbenchProjectDiscoveryResult {
+	readonly outcome: TestbenchDiscoveryOutcome;
+	readonly project: HdlProjectModel;
+	readonly testbenches: readonly DiscoveredTestbench[];
+	readonly command?: TestbenchProcessRequest;
+	readonly exitCode?: number;
+	readonly rawOutput: {
+		readonly stdout: string;
+		readonly stderr: string;
+	};
+	readonly message: string;
+}
+
+export interface TestbenchDiscoveryResult {
+	readonly outcome: TestbenchDiscoveryOutcome;
+	readonly discovery: typeof testbenchDiscoveryExecution;
+	readonly projects: readonly TestbenchProjectDiscoveryResult[];
+	readonly message: string;
+}
+
+const defaultMakeExecutable = 'make';
+const defaultSlowThresholdMs = 5000;
+
+export const nodeTestbenchProcessRunner: TestbenchProcessRunner = {
+	run(request, events) {
+		return new Promise((resolve, reject) => {
+			const childProcess = spawn(
+				request.executablePath,
+				[...request.args],
+				{
+					cwd: request.cwd,
+					env: request.env,
+					shell: false,
+					signal: request.signal,
+				},
+			);
+
+			childProcess.stdout.setEncoding('utf8');
+			childProcess.stderr.setEncoding('utf8');
+			childProcess.stdout.on('data', (chunk: string) => events.onStdout(chunk));
+			childProcess.stderr.on('data', (chunk: string) => events.onStderr(chunk));
+			childProcess.on('error', reject);
+			childProcess.on('close', (code, signal) => {
+				resolve({
+					exitCode: code ?? 1,
+					signal: signal ?? undefined,
+				});
+			});
+		});
+	},
+};
+
+export class TestbenchDiscoveryService {
+	private readonly inFlightByProjectRoot = new Map<string, Promise<TestbenchProjectDiscoveryResult>>();
+
+	public async discoverWorkspace(
+		options: TestbenchDiscoveryOptions,
+	): Promise<TestbenchDiscoveryResult> {
+		options.output.show(true);
+
+		if (!options.workspaceTrusted) {
+			const message = 'Workspace trust is required before HDL Dev can run Make targets.';
+			writeWorkspaceHeader(options.output, message);
+			options.output.appendLine(`[error] ${message}`);
+			return {
+				outcome: 'blocked',
+				discovery: testbenchDiscoveryExecution,
+				projects: [],
+				message,
+			};
+		}
+
+		const discoveryResult = await discoverHdlProjects({
+			workspaceFolderPaths: options.workspaceFolderPaths,
+			configuredRootPaths: options.configuredRootPaths,
+		});
+
+		if (discoveryResult.projects.length === 0) {
+			const message = 'No HDL projects were found for testbench discovery.';
+			writeWorkspaceHeader(options.output, message);
+			options.output.appendLine(`[warn] ${message}`);
+			return {
+				outcome: 'noProjects',
+				discovery: testbenchDiscoveryExecution,
+				projects: [],
+				message,
+			};
+		}
+
+		writeWorkspaceHeader(options.output, 'Discovering GHDL testbenches');
+		const projects = await Promise.all(
+			discoveryResult.projects.map((project) => this.discoverProject(project, options)),
+		);
+
+		return {
+			outcome: aggregateProjectOutcomes(projects),
+			discovery: testbenchDiscoveryExecution,
+			projects,
+			message: formatWorkspaceMessage(projects),
+		};
+	}
+
+	private discoverProject(
+		project: HdlProjectModel,
+		options: TestbenchDiscoveryOptions,
+	): Promise<TestbenchProjectDiscoveryResult> {
+		const existing = this.inFlightByProjectRoot.get(project.rootPath);
+
+		if (existing !== undefined) {
+			return existing;
+		}
+
+		const promise = this.runProjectDiscovery(project, options)
+			.finally(() => {
+				this.inFlightByProjectRoot.delete(project.rootPath);
+			});
+		this.inFlightByProjectRoot.set(project.rootPath, promise);
+		return promise;
+	}
+
+	private async runProjectDiscovery(
+		project: HdlProjectModel,
+		options: TestbenchDiscoveryOptions,
+	): Promise<TestbenchProjectDiscoveryResult> {
+		const runner = options.runner ?? nodeTestbenchProcessRunner;
+		const makeExecutable = normalizeMakeExecutable(options.makeExecutable);
+		const env = buildTestbenchDiscoveryEnvironment(
+			options.env ?? process.env,
+			options.environmentOverrides ?? {},
+		);
+		const request: TestbenchProcessRequest = {
+			executablePath: makeExecutable,
+			args: ['list-tbs'],
+			cwd: project.rootPath,
+			env,
+			signal: options.cancellationSignal,
+		};
+		const rawOutput = {
+			stdout: '',
+			stderr: '',
+		};
+
+		if (isCancellationRequested(options.cancellationSignal)) {
+			const message = `Cancelled testbench discovery for ${project.rootPath}`;
+			options.output.appendLine(`[cancelled] ${message}`);
+			options.stateSink?.setProjectState({
+				projectRootPath: project.rootPath,
+				state: 'cancelled',
+				message,
+			});
+			return {
+				outcome: 'cancelled',
+				project,
+				testbenches: [],
+				command: request,
+				rawOutput,
+				message,
+			};
+		}
+
+		options.stateSink?.setProjectState({
+			projectRootPath: project.rootPath,
+			state: 'discovering',
+			message: `Discovering testbenches in ${project.rootPath}`,
+		});
+		writeProjectExecutionDetails(options.output, project, request);
+
+		let slowTimer: NodeJS.Timeout | undefined;
+		const slowThresholdMs = Math.max(0, options.slowThresholdMs ?? defaultSlowThresholdMs);
+
+		if (slowThresholdMs >= 0) {
+			slowTimer = setTimeout(() => {
+				const message = `Testbench discovery is still running for ${project.rootPath}`;
+				options.output.appendLine(`[warn] ${message}`);
+				options.stateSink?.setProjectState({
+					projectRootPath: project.rootPath,
+					state: 'slow',
+					message,
+				});
+			}, slowThresholdMs);
+		}
+
+		try {
+			const processResult = await runner.run(request, {
+				onStdout: (chunk) => {
+					rawOutput.stdout += chunk;
+					options.output.append(chunk);
+				},
+				onStderr: (chunk) => {
+					rawOutput.stderr += chunk;
+					options.output.append(chunk);
+				},
+			});
+
+			if (processResult.signal !== undefined || isCancellationRequested(options.cancellationSignal)) {
+				const message = `Cancelled testbench discovery for ${project.rootPath}`;
+				options.output.appendLine('');
+				options.output.appendLine(`[cancelled] ${message}`);
+				options.stateSink?.setProjectState({
+					projectRootPath: project.rootPath,
+					state: 'cancelled',
+					message,
+				});
+				return {
+					outcome: 'cancelled',
+					project,
+					testbenches: [],
+					command: request,
+					exitCode: processResult.exitCode,
+					rawOutput,
+					message,
+				};
+			}
+
+			if (processResult.exitCode !== 0) {
+				const message = `make list-tbs failed for ${project.rootPath} with exit code ${processResult.exitCode}`;
+				options.output.appendLine('');
+				options.output.appendLine(`[error] ${message}`);
+				options.stateSink?.setProjectState({
+					projectRootPath: project.rootPath,
+					state: 'failed',
+					message,
+				});
+				return {
+					outcome: 'failed',
+					project,
+					testbenches: [],
+					command: request,
+					exitCode: processResult.exitCode,
+					rawOutput,
+					message,
+				};
+			}
+
+			const testbenches = parseTestbenchList(rawOutput.stdout).map((name) => ({
+				id: createTestbenchItemId(project.rootPath, name),
+				name,
+				projectRootPath: project.rootPath,
+				projectNamespace: project.rootPath,
+			}));
+
+			if (testbenches.length === 0) {
+				const message = `No testbenches were reported by ${project.rootPath}`;
+				options.output.appendLine('');
+				options.output.appendLine(`[warn] ${message}`);
+				options.stateSink?.setProjectState({
+					projectRootPath: project.rootPath,
+					state: 'empty',
+					message,
+				});
+				return {
+					outcome: 'empty',
+					project,
+					testbenches,
+					command: request,
+					exitCode: processResult.exitCode,
+					rawOutput,
+					message,
+				};
+			}
+
+			const message = `Discovered ${testbenches.length} testbench${testbenches.length === 1 ? '' : 'es'} in ${project.rootPath}`;
+			options.output.appendLine('');
+			options.output.appendLine(`[ok] ${message}`);
+			options.stateSink?.setProjectState({
+				projectRootPath: project.rootPath,
+				state: 'discovered',
+				message,
+			});
+			return {
+				outcome: 'discovered',
+				project,
+				testbenches,
+				command: request,
+				exitCode: processResult.exitCode,
+				rawOutput,
+				message,
+			};
+		} catch (error) {
+			if (isAbortError(error) || isCancellationRequested(options.cancellationSignal)) {
+				const message = `Cancelled testbench discovery for ${project.rootPath}`;
+				options.output.appendLine('');
+				options.output.appendLine(`[cancelled] ${message}`);
+				options.stateSink?.setProjectState({
+					projectRootPath: project.rootPath,
+					state: 'cancelled',
+					message,
+				});
+				return {
+					outcome: 'cancelled',
+					project,
+					testbenches: [],
+					command: request,
+					rawOutput,
+					message,
+				};
+			}
+
+			const message = `Failed to run make list-tbs for ${project.rootPath}: ${errorMessage(error)}`;
+			options.output.appendLine('');
+			options.output.appendLine(`[error] ${message}`);
+			options.stateSink?.setProjectState({
+				projectRootPath: project.rootPath,
+				state: 'failed',
+				message,
+			});
+			return {
+				outcome: 'failed',
+				project,
+				testbenches: [],
+				command: request,
+				rawOutput,
+				message,
+			};
+		} finally {
+			if (slowTimer !== undefined) {
+				clearTimeout(slowTimer);
+			}
+		}
+	}
+}
+
+export function parseTestbenchList(output: string): string[] {
+	const testbenchNames: string[] = [];
+	const seen = new Set<string>();
+
+	for (const line of output.split(/\r?\n/)) {
+		const testbenchName = line.trim();
+
+		if (testbenchName === '' || testbenchName.startsWith('#') || seen.has(testbenchName)) {
+			continue;
+		}
+
+		seen.add(testbenchName);
+		testbenchNames.push(testbenchName);
+	}
+
+	return testbenchNames;
+}
+
+export function createTestbenchItemId(projectRootPath: string, testbenchName: string): string {
+	return `${path.resolve(projectRootPath)}::${testbenchName}`;
+}
+
+export function buildTestbenchDiscoveryEnvironment(
+	baseEnv: NodeJS.ProcessEnv = process.env,
+	overrides: NodeJS.ProcessEnv = {},
+): NodeJS.ProcessEnv {
+	const env: NodeJS.ProcessEnv = {
+		...baseEnv,
+		...overrides,
+	};
+
+	if (env.GHDL_TOOLCHAIN_ROOT !== undefined && env.GHDL_TOOLCHAIN_ROOT.trim() !== '') {
+		const ghdlBinPath = path.join(env.GHDL_TOOLCHAIN_ROOT, 'bin');
+		env.PATH = env.PATH === undefined || env.PATH === ''
+			? ghdlBinPath
+			: `${ghdlBinPath}${path.delimiter}${env.PATH}`;
+	}
+
+	return env;
+}
+
+function normalizeMakeExecutable(makeExecutable: string | undefined): string {
+	const trimmed = makeExecutable?.trim() ?? '';
+	return trimmed === '' ? defaultMakeExecutable : trimmed;
+}
+
+function writeWorkspaceHeader(
+	output: TestbenchDiscoveryOutput,
+	message: string,
+): void {
+	output.appendLine('');
+	output.appendLine(`[HDL Dev] ${message}`);
+	output.appendLine('[HDL Dev] Profile: testbench-discovery');
+}
+
+function writeProjectExecutionDetails(
+	output: TestbenchDiscoveryOutput,
+	project: HdlProjectModel,
+	request: TestbenchProcessRequest,
+): void {
+	output.appendLine(`[HDL Dev] Project root: ${project.rootPath}`);
+	output.appendLine(`[HDL Dev] Executable: ${request.executablePath}`);
+	output.appendLine(`[HDL Dev] Arguments: ${JSON.stringify(request.args)}`);
+	output.appendLine(`[HDL Dev] Working directory: ${request.cwd}`);
+	output.appendLine('');
+}
+
+function aggregateProjectOutcomes(
+	projects: readonly TestbenchProjectDiscoveryResult[],
+): TestbenchDiscoveryOutcome {
+	if (projects.some((project) => project.outcome === 'discovered')) {
+		return 'discovered';
+	}
+
+	if (projects.every((project) => project.outcome === 'cancelled')) {
+		return 'cancelled';
+	}
+
+	if (projects.every((project) => project.outcome === 'failed')) {
+		return 'failed';
+	}
+
+	if (projects.every((project) => project.outcome === 'empty')) {
+		return 'empty';
+	}
+
+	if (projects.every((project) => project.outcome === 'blocked')) {
+		return 'blocked';
+	}
+
+	return 'failed';
+}
+
+function formatWorkspaceMessage(
+	projects: readonly TestbenchProjectDiscoveryResult[],
+): string {
+	const count = projects.reduce(
+		(total, project) => total + project.testbenches.length,
+		0,
+	);
+	return `Discovered ${count} testbench${count === 1 ? '' : 'es'} across ${projects.length} project${projects.length === 1 ? '' : 's'}`;
+}
+
+function isAbortError(error: unknown): boolean {
+	return error instanceof Error && error.name === 'AbortError';
+}
+
+function isCancellationRequested(signal: AbortSignal | undefined): boolean {
+	return signal?.aborted === true;
+}
+
+function errorMessage(error: unknown): string {
+	if (error instanceof Error) {
+		return error.message;
+	}
+
+	return String(error);
+}


### PR DESCRIPTION
## Summary

Refs #4.

- Add a Make-backed testbench discovery service that runs `make list-tbs` with explicit process arguments from each discovered HDL project root.
- Parse line-oriented testbench names into stable per-project IDs, preserve raw stdout/stderr, report empty/failed/slow/cancelled states, and de-dupe concurrent discovery for the same project root.
- Register an `HDL Dev Testbenches` TestController that discovers on Testing API resolve/refresh instead of extension activation.
- Document the v0.2 discovery contract and managed Makefile pattern.

## Validation

- `npm run compile`
- `npm run lint`
- `env XDG_RUNTIME_DIR=/tmp/hdl-dev-vscode-runtime npm test` - 19 passing
- `make docs-build`
- `git diff --check`

## CI Evidence

- CI: https://github.com/cosgroma/vscode-hdl-dev/actions/runs/24622270060
- Pages: https://github.com/cosgroma/vscode-hdl-dev/actions/runs/24622270052
- Doctor GHDL Smoke: https://github.com/cosgroma/vscode-hdl-dev/actions/runs/24622270059
- Git Flow Policy: https://github.com/cosgroma/vscode-hdl-dev/actions/runs/24622270067

## Manual Fixture Transcript

Compiled discovery service against a temporary managed-style Makefile fixture:

```text
[HDL Dev] Discovering GHDL testbenches
[HDL Dev] Profile: testbench-discovery
[HDL Dev] Project root: /tmp/hdl-dev-manual-tb-ErlwmE/pcores/timer
[HDL Dev] Executable: make
[HDL Dev] Arguments: ["list-tbs"]
[HDL Dev] Working directory: /tmp/hdl-dev-manual-tb-ErlwmE/pcores/timer

timer_tb
uart_tb
fifo_tb

[ok] Discovered 3 testbenches in /tmp/hdl-dev-manual-tb-ErlwmE/pcores/timer
```
