### PR TITLE
Run testbenches through the VS Code Testing API

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 HDL Dev is a VS Code extension for coordinating HDL project workflows from
 inside the editor. The project is currently an early TypeScript extension with
 passive HDL project discovery, dependency-check commands, testbench discovery,
-documentation, CI, and GitHub Pages infrastructure in place.
+testbench run support, documentation, CI, and GitHub Pages infrastructure in
+place.
 
 The design direction is to keep HDL project scripts as the source of truth and
 wrap them with native VS Code surfaces: commands, Output channels, the Testing
@@ -12,7 +13,8 @@ API, tree views, status items, and focused artifact previews.
 ## Features
 
 Current shipped extension behavior covers the v0.1 Project Discovery and
-Dependency Doctor milestone plus the first v0.2 testbench discovery slice.
+Dependency Doctor milestone plus the v0.2 native testbench discovery and run
+implementation slices.
 
 Feature status:
 
@@ -29,7 +31,7 @@ Feature status:
 - [x] Dependency Doctor commands and Output channel
 - [x] dependency status bar item
 - [x] VS Code Testing API testbench discovery
-- [ ] VS Code Testing API testbench run support
+- [x] VS Code Testing API testbench run support
 - [ ] waveform spec tree and SVG generation commands
 - [ ] schematic spec tree and SVG generation commands
 - [ ] generated artifact explorer
@@ -43,10 +45,13 @@ Shipped command names use the `HDL Dev` prefix:
 - `HDL Dev: Check GHDL Dependencies`
 - `HDL Dev: Check Documentation Asset Dependencies`
 
+Shipped Testing API surface:
+
+- `HDL Dev Testbenches` test controller
+- `Run Testbench` run profile
+
 Planned command names:
 
-- `HDL Dev: List Testbenches`
-- `HDL Dev: Run Testbench`
 - `HDL Dev: Generate Waveform SVG`
 - `HDL Dev: Generate Schematic SVG`
 - `HDL Dev: Open Latest Artifact`
@@ -91,12 +96,9 @@ HDL Dev contributes these settings:
 - `hdlDev.projectRoots`: optional explicit project roots
 - `hdlDev.depsScript`: optional path to `scripts/deps.sh`
 - `hdlDev.makeExecutable`: make executable path, defaulting to `make`
+- `hdlDev.defaultStopTime`: default `STOP_TIME` for GHDL testbench runs
+- `hdlDev.defaultWaveFormat`: default `WAVE_FORMAT` for GHDL testbench runs
 - `hdlDev.toolchainRoot`: optional `GHDL_TOOLCHAIN_ROOT`
-
-Planned settings:
-
-- `hdlDev.defaultStopTime`: default GHDL stop time, for example `500us`
-- `hdlDev.defaultWaveFormat`: default wave format, initially `ghw`
 
 ## Repository Workflow
 
@@ -149,8 +151,9 @@ generation.
 - Dependency Doctor uses coarse pass/fail process status and human-readable
   shell output; JSON output is planned for more reliable extension integration.
 - Dependency Doctor commands are blocked until the workspace is trusted.
-- Testbench running, spec trees, artifact navigation, previews, schemas, and
-  packetized-I/O debug helpers are planned but not implemented yet.
+- Testbench result status is currently based on Make process exit status.
+- Spec trees, artifact navigation, previews, schemas, and packetized-I/O debug
+  helpers are planned but not implemented yet.
 - Waveform and schematic generation are documented as design targets but are not
   implemented in the extension yet.
 
@@ -164,6 +167,7 @@ Initial scaffold and project infrastructure:
 - repo-owned dependency scripts and Make targets
 - passive HDL project discovery
 - Dependency Doctor commands, Output channel, and status item
+- VS Code Testing API discovery and Make-backed testbench runs
 - cached GHDL Doctor smoke workflow
 - git-flow branch model
 - MkDocs GitHub Pages deployment
@@ -175,7 +179,7 @@ Design notes live under `docs/` and are published through MkDocs:
 - [VS Code Workbench References](docs/references/vscode-workbench-surfaces.md)
 - [GEnCor Integration Notes](docs/integrations/gencor.md)
 - [v0.1 Project Discovery And Dependency Doctor](docs/workflows/v0.1-project-discovery-and-doctor.md)
-- [v0.2 Testbench Discovery](docs/workflows/v0.2-testbench-discovery.md)
+- [v0.2 Native Testbench Runner](docs/workflows/v0.2-testbench-discovery.md)
 - [Project Discovery](docs/design/project-discovery.md)
 - [Initial Extension Design](docs/design/initial-extension-design.md)
 - [MVP Roadmap](docs/design/mvp-roadmap.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,9 +15,9 @@ repo's own extension-facing command-line workflow.
 - [v0.1 Project Discovery And Dependency Doctor](workflows/v0.1-project-discovery-and-doctor.md)
   describes the shipped discovery and dependency-check workflow, expected
   output, trust behavior, and evidence coverage.
-- [v0.2 Testbench Discovery](workflows/v0.2-testbench-discovery.md) describes
-  the `make list-tbs` discovery contract, Testing API surface, trust behavior,
-  and managed Makefile pattern.
+- [v0.2 Native Testbench Runner](workflows/v0.2-testbench-discovery.md)
+  describes the `make list-tbs` discovery contract, `make test` run contract,
+  Testing API surface, trust behavior, and managed Makefile pattern.
 - [Initial Extension Design](design/initial-extension-design.md) describes the
   proposed feature areas, VS Code surfaces, and implementation boundaries.
 - [Project Discovery](design/project-discovery.md) documents the passive

--- a/docs/workflows/v0.2-testbench-discovery.md
+++ b/docs/workflows/v0.2-testbench-discovery.md
@@ -1,9 +1,11 @@
-# v0.2 Testbench Discovery
+# v0.2 Native Testbench Runner
 
 HDL Dev discovers GHDL testbenches by asking each detected HDL project to list
-its own testbench names. The project Makefile remains the source of truth.
+its own testbench names. It runs those testbenches by asking the same project
+Makefile to execute a named test. The project Makefile remains the source of
+truth.
 
-## Make Contract
+## Discovery Contract
 
 The extension invokes this command from each project root:
 
@@ -41,6 +43,27 @@ the extension. Larger projects can later include shared Make fragments such as
 `scripts/hdl-dev-ghdl.mk`, but those fragments should still live in the project
 repository and expose the same `list-tbs` target.
 
+## Run Contract
+
+The extension runs one discovered testbench at a time with this command shape:
+
+```bash
+make test TB=<testbench> STOP_TIME=<time> WAVE_FORMAT=<ghw|fst|vcd>
+```
+
+HDL Dev passes each Make variable assignment as its own process argument. The
+default values come from extension settings:
+
+```text
+STOP_TIME=500us
+WAVE_FORMAT=ghw
+```
+
+A zero exit code marks the test passed. A nonzero exit code marks the test
+failed. Process launch errors are surfaced as test errors. Raw standard output
+and standard error are streamed into both the VS Code test result output and the
+HDL Dev Output channel.
+
 ## VS Code Surface
 
 The extension registers an `HDL Dev Testbenches` TestController. Testbench
@@ -51,19 +74,28 @@ Each discovered project is represented as a separate test namespace. Testbench
 item IDs include the project root path, so two roots can both expose a
 `timer_tb` without colliding.
 
+The controller contributes a default `Run Testbench` profile. Running a project
+item runs its discovered child testbenches. Running a single testbench invokes
+the Make run contract for only that testbench.
+
 ## Trust And Cancellation
 
-`make list-tbs` is a workspace command. Discovery is blocked until the workspace
-is trusted.
+`make list-tbs` and `make test ...` are workspace commands. Discovery and runs
+are blocked until the workspace is trusted.
 
-Refresh cancellation is forwarded to the spawned Make process. Slow discovery
-is reported through the discovery state model while allowing Make to complete.
+Refresh cancellation is forwarded to the spawned discovery Make process. Test
+run cancellation is forwarded to the spawned `make test` process.
+
+Runs that share a project root are serialized so two simulations do not race in
+the same build directory. Different project roots can run independently.
 
 ## Settings
 
 - `hdlDev.projectRoots`: optional explicit HDL project roots. Relative paths
   resolve under each workspace folder.
 - `hdlDev.makeExecutable`: Make executable path, defaulting to `make`.
+- `hdlDev.defaultStopTime`: default `STOP_TIME`, defaulting to `500us`.
+- `hdlDev.defaultWaveFormat`: default `WAVE_FORMAT`, defaulting to `ghw`.
 - `hdlDev.toolchainRoot`: optional GHDL toolchain root. When set, HDL Dev passes
   it as `GHDL_TOOLCHAIN_ROOT` and prepends its `bin` directory to `PATH`.
 
@@ -71,6 +103,7 @@ is reported through the discovery state model while allowing Make to complete.
 
 - Discovery is line-oriented; Makefiles should keep `list-tbs` output concise
   and machine-facing.
-- Running testbenches is not implemented yet.
+- Test result status is based on Make process exit status. Richer parsing can
+  be added later if project scripts emit machine-readable output.
 - The extension does not generate or inject managed Makefiles. Shared recipe
   templates should be added as project-local files when needed.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,7 +17,7 @@ nav:
       - GEnCor: integrations/gencor.md
   - Workflows:
       - v0.1 Project Discovery And Dependency Doctor: workflows/v0.1-project-discovery-and-doctor.md
-      - v0.2 Testbench Discovery: workflows/v0.2-testbench-discovery.md
+      - v0.2 Native Testbench Runner: workflows/v0.2-testbench-discovery.md
   - Design:
       - Project Discovery: design/project-discovery.md
       - Initial Extension Design: design/initial-extension-design.md

--- a/package.json
+++ b/package.json
@@ -49,6 +49,21 @@
           "default": "make",
           "description": "Make executable used for HDL project testbench discovery and runs."
         },
+        "hdlDev.defaultStopTime": {
+          "type": "string",
+          "default": "500us",
+          "description": "Default STOP_TIME value passed to Make-backed GHDL testbench runs."
+        },
+        "hdlDev.defaultWaveFormat": {
+          "type": "string",
+          "enum": [
+            "ghw",
+            "fst",
+            "vcd"
+          ],
+          "default": "ghw",
+          "description": "Default WAVE_FORMAT value passed to Make-backed GHDL testbench runs."
+        },
         "hdlDev.toolchainRoot": {
           "type": "string",
           "default": "",

--- a/src/test/testbenchRun.test.ts
+++ b/src/test/testbenchRun.test.ts
@@ -1,0 +1,287 @@
+import * as assert from 'node:assert';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import {
+	buildTestbenchRunRequest,
+	TestbenchRunService,
+	type TestbenchRunOutput,
+	type TestbenchRunTarget,
+} from '../testbench/testbenchRun';
+import type {
+	TestbenchProcessEvents,
+	TestbenchProcessRequest,
+	TestbenchProcessResult,
+	TestbenchProcessRunner,
+} from '../testbench/testbenchDiscovery';
+
+const tempRoots: string[] = [];
+
+suite('Testbench Run', () => {
+	teardown(async () => {
+		await Promise.all(tempRoots.splice(0).map(async (tempRoot) => {
+			await fs.rm(tempRoot, { recursive: true, force: true });
+		}));
+	});
+
+	test('builds make test requests with explicit process arguments', async () => {
+		const projectPath = await createTempProject();
+		const target = createTarget(projectPath, 'timer_tb');
+		const output = new CapturingOutput();
+		const runner = new FakeProcessRunner({
+			exitCode: 0,
+			stdout: '[ok] timer_tb\n',
+		});
+
+		const result = await new TestbenchRunService().runTestbench(target, {
+			workspaceTrusted: true,
+			makeExecutable: 'gmake',
+			defaultStopTime: '1us',
+			defaultWaveFormat: 'fst',
+			env: { PATH: '/usr/bin' },
+			output,
+			runner,
+		});
+
+		assert.strictEqual(result.outcome, 'passed');
+		assert.strictEqual(runner.requests.length, 1);
+		assert.strictEqual(runner.requests[0].executablePath, 'gmake');
+		assert.deepStrictEqual(
+			runner.requests[0].args,
+			['test', 'TB=timer_tb', 'STOP_TIME=1us', 'WAVE_FORMAT=fst'],
+		);
+		assert.strictEqual(runner.requests[0].cwd, projectPath);
+		assert.strictEqual(result.rawOutput.stdout, '[ok] timer_tb\n');
+		assert.match(output.text, /\[ok\] timer_tb/);
+	});
+
+	test('maps nonzero exits and runner errors to failed and errored outcomes', async () => {
+		const projectPath = await createTempProject();
+		const target = createTarget(projectPath, 'timer_tb');
+		const failedResult = await new TestbenchRunService().runTestbench(target, {
+			workspaceTrusted: true,
+			output: new CapturingOutput(),
+			runner: new FakeProcessRunner({
+				exitCode: 2,
+				stderr: '[fail] assertion mismatch\n',
+			}),
+		});
+
+		assert.strictEqual(failedResult.outcome, 'failed');
+		assert.strictEqual(failedResult.exitCode, 2);
+		assert.match(failedResult.rawOutput.stderr, /assertion mismatch/);
+
+		const erroredResult = await new TestbenchRunService().runTestbench(target, {
+			workspaceTrusted: true,
+			output: new CapturingOutput(),
+			runner: new ThrowingProcessRunner(new Error('make unavailable')),
+		});
+
+		assert.strictEqual(erroredResult.outcome, 'errored');
+		assert.match(erroredResult.message, /make unavailable/);
+	});
+
+	test('forwards cancellation to the process request and reports cancellation', async () => {
+		const projectPath = await createTempProject();
+		const target = createTarget(projectPath, 'timer_tb');
+		const abortController = new AbortController();
+		const runner = new FakeProcessRunner((request) => {
+			assert.strictEqual(request.signal, abortController.signal);
+			abortController.abort();
+			return {
+				exitCode: 1,
+				signal: 'SIGTERM',
+			};
+		});
+
+		const result = await new TestbenchRunService().runTestbench(target, {
+			workspaceTrusted: true,
+			output: new CapturingOutput(),
+			runner,
+			cancellationSignal: abortController.signal,
+		});
+
+		assert.strictEqual(result.outcome, 'cancelled');
+		assert.strictEqual(runner.requests.length, 1);
+	});
+
+	test('does not run Make when workspace trust is missing or cancellation is already requested', async () => {
+		const projectPath = await createTempProject();
+		const target = createTarget(projectPath, 'timer_tb');
+		const runner = new FakeProcessRunner({
+			exitCode: 0,
+		});
+		const blockedResult = await new TestbenchRunService().runTestbench(target, {
+			workspaceTrusted: false,
+			output: new CapturingOutput(),
+			runner,
+		});
+		const abortController = new AbortController();
+		abortController.abort();
+		const cancelledResult = await new TestbenchRunService().runTestbench(target, {
+			workspaceTrusted: true,
+			output: new CapturingOutput(),
+			runner,
+			cancellationSignal: abortController.signal,
+		});
+
+		assert.strictEqual(blockedResult.outcome, 'blocked');
+		assert.strictEqual(cancelledResult.outcome, 'cancelled');
+		assert.strictEqual(runner.requests.length, 0);
+	});
+
+	test('serializes runs that share a project root', async () => {
+		const projectPath = await createTempProject();
+		const service = new TestbenchRunService();
+		let activeRuns = 0;
+		let maxActiveRuns = 0;
+		const runner = new FakeProcessRunner(async () => {
+			activeRuns += 1;
+			maxActiveRuns = Math.max(maxActiveRuns, activeRuns);
+			await delay(20);
+			activeRuns -= 1;
+			return {
+				exitCode: 0,
+				stdout: '[ok]\n',
+			};
+		});
+
+		await Promise.all([
+			service.runTestbench(createTarget(projectPath, 'timer_tb'), {
+				workspaceTrusted: true,
+				output: new CapturingOutput(),
+				runner,
+			}),
+			service.runTestbench(createTarget(projectPath, 'uart_tb'), {
+				workspaceTrusted: true,
+				output: new CapturingOutput(),
+				runner,
+			}),
+		]);
+
+		assert.strictEqual(maxActiveRuns, 1);
+		assert.deepStrictEqual(
+			runner.requests.map((request) => request.args[1]),
+			['TB=timer_tb', 'TB=uart_tb'],
+		);
+	});
+
+	test('package contributes testbench run settings', async () => {
+		const packageJsonPath = path.join(__dirname, '..', '..', 'package.json');
+		const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf8')) as {
+			contributes: {
+				configuration: {
+					properties: Record<string, {
+						default?: string;
+						enum?: string[];
+					}>;
+				};
+			};
+		};
+		const properties = packageJson.contributes.configuration.properties;
+
+		assert.strictEqual(properties['hdlDev.defaultStopTime'].default, '500us');
+		assert.deepStrictEqual(properties['hdlDev.defaultWaveFormat'].enum, ['ghw', 'fst', 'vcd']);
+	});
+
+	test('normalizes empty or unsupported run setting values', async () => {
+		const projectPath = await createTempProject();
+		const request = buildTestbenchRunRequest(createTarget(projectPath, 'timer_tb'), {
+			makeExecutable: '',
+			defaultStopTime: '',
+			defaultWaveFormat: 'unsupported',
+			env: {},
+		});
+
+		assert.strictEqual(request.executablePath, 'make');
+		assert.deepStrictEqual(
+			request.args,
+			['test', 'TB=timer_tb', 'STOP_TIME=500us', 'WAVE_FORMAT=ghw'],
+		);
+	});
+});
+
+class CapturingOutput implements TestbenchRunOutput {
+	public text = '';
+	public shown = false;
+
+	append(value: string): void {
+		this.text += value;
+	}
+
+	appendLine(value: string): void {
+		this.text += `${value}\n`;
+	}
+
+	show(): void {
+		this.shown = true;
+	}
+}
+
+type FakeProcessResponse = TestbenchProcessResult & {
+	readonly stdout?: string;
+	readonly stderr?: string;
+	readonly delayMs?: number;
+};
+
+type FakeProcessHandler = (request: TestbenchProcessRequest) => FakeProcessResponse | Promise<FakeProcessResponse>;
+
+class FakeProcessRunner implements TestbenchProcessRunner {
+	public readonly requests: TestbenchProcessRequest[] = [];
+	private readonly handler: FakeProcessHandler;
+
+	public constructor(response: FakeProcessResponse | FakeProcessHandler) {
+		this.handler = typeof response === 'function' ? response : () => response;
+	}
+
+	public async run(
+		request: TestbenchProcessRequest,
+		events: TestbenchProcessEvents,
+	): Promise<TestbenchProcessResult> {
+		this.requests.push(request);
+		const response = await this.handler(request);
+
+		if (response.delayMs !== undefined) {
+			await delay(response.delayMs);
+		}
+
+		if (response.stdout !== undefined) {
+			events.onStdout(response.stdout);
+		}
+
+		if (response.stderr !== undefined) {
+			events.onStderr(response.stderr);
+		}
+
+		return response;
+	}
+}
+
+class ThrowingProcessRunner implements TestbenchProcessRunner {
+	public constructor(private readonly error: Error) {}
+
+	public run(): Promise<TestbenchProcessResult> {
+		return Promise.reject(this.error);
+	}
+}
+
+async function createTempProject(): Promise<string> {
+	const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'hdl-dev-testbench-run-'));
+	tempRoots.push(tempRoot);
+	await fs.mkdir(tempRoot, { recursive: true });
+	return tempRoot;
+}
+
+function createTarget(projectRootPath: string, name: string): TestbenchRunTarget {
+	return {
+		id: `${projectRootPath}::${name}`,
+		name,
+		projectRootPath,
+		projectNamespace: projectRootPath,
+	};
+}
+
+async function delay(delayMs: number): Promise<void> {
+	await new Promise((resolve) => setTimeout(resolve, delayMs));
+}

--- a/src/testbench/testbenchController.ts
+++ b/src/testbench/testbenchController.ts
@@ -5,11 +5,22 @@ import * as vscode from 'vscode';
 import {
 	createTestbenchItemId,
 	TestbenchDiscoveryService,
+	type DiscoveredTestbench,
 	type TestbenchDiscoveryResult,
 	type TestbenchProjectDiscoveryResult,
 } from './testbenchDiscovery';
+import {
+	TestbenchRunService,
+	type TestbenchRunResult,
+	type TestbenchRunTarget,
+} from './testbenchRun';
 
 export const testbenchControllerId = 'vscode-hdl-dev.testbenches';
+
+interface RunnableTestbenchItem {
+	readonly item: vscode.TestItem;
+	readonly target: TestbenchRunTarget;
+}
 
 export function registerTestbenchController(
 	context: vscode.ExtensionContext,
@@ -20,6 +31,8 @@ export function registerTestbenchController(
 		'HDL Dev Testbenches',
 	);
 	const discoveryService = new TestbenchDiscoveryService();
+	const runService = new TestbenchRunService();
+	const runnableTestbenchesByItemId = new Map<string, RunnableTestbenchItem>();
 
 	const refresh = async (token?: vscode.CancellationToken): Promise<void> => {
 		const configuration = vscode.workspace.getConfiguration('hdlDev');
@@ -45,7 +58,7 @@ export function registerTestbenchController(
 				output: outputChannel,
 				cancellationSignal: abortController.signal,
 			});
-			replaceTestItems(controller, result);
+			replaceTestItems(controller, result, runnableTestbenchesByItemId);
 		} finally {
 			cancellationSubscription?.dispose();
 		}
@@ -57,6 +70,19 @@ export function registerTestbenchController(
 			await refresh();
 		}
 	};
+	controller.createRunProfile(
+		'Run Testbench',
+		vscode.TestRunProfileKind.Run,
+		(request, token) => runTestbenches(
+			controller,
+			runnableTestbenchesByItemId,
+			runService,
+			outputChannel,
+			request,
+			token,
+		),
+		true,
+	);
 
 	context.subscriptions.push(controller);
 }
@@ -64,15 +90,22 @@ export function registerTestbenchController(
 function replaceTestItems(
 	controller: vscode.TestController,
 	result: TestbenchDiscoveryResult,
+	runnableTestbenchesByItemId: Map<string, RunnableTestbenchItem>,
 ): void {
+	runnableTestbenchesByItemId.clear();
 	controller.items.replace(
-		result.projects.map((projectResult) => createProjectTestItem(controller, projectResult)),
+		result.projects.map((projectResult) => createProjectTestItem(
+			controller,
+			projectResult,
+			runnableTestbenchesByItemId,
+		)),
 	);
 }
 
 function createProjectTestItem(
 	controller: vscode.TestController,
 	projectResult: TestbenchProjectDiscoveryResult,
+	runnableTestbenchesByItemId: Map<string, RunnableTestbenchItem>,
 ): vscode.TestItem {
 	const project = projectResult.project;
 	const projectItem = controller.createTestItem(
@@ -88,19 +121,213 @@ function createProjectTestItem(
 	}
 
 	projectItem.children.replace(
-		projectResult.testbenches.map((testbench) => {
-			const testbenchItem = controller.createTestItem(
-				createTestbenchItemId(testbench.projectRootPath, testbench.name),
-				testbench.name,
-				vscode.Uri.file(project.makefilePath),
-			);
-			testbenchItem.canResolveChildren = false;
-			testbenchItem.description = project.rootPath;
-			return testbenchItem;
-		}),
+		projectResult.testbenches.map((testbench) => createTestbenchTestItem(
+			controller,
+			testbench,
+			project.makefilePath,
+			runnableTestbenchesByItemId,
+		)),
 	);
 
 	return projectItem;
+}
+
+function createTestbenchTestItem(
+	controller: vscode.TestController,
+	testbench: DiscoveredTestbench,
+	makefilePath: string,
+	runnableTestbenchesByItemId: Map<string, RunnableTestbenchItem>,
+): vscode.TestItem {
+	const testbenchItem = controller.createTestItem(
+		createTestbenchItemId(testbench.projectRootPath, testbench.name),
+		testbench.name,
+		vscode.Uri.file(makefilePath),
+	);
+	testbenchItem.canResolveChildren = false;
+	testbenchItem.description = testbench.projectRootPath;
+	runnableTestbenchesByItemId.set(testbenchItem.id, {
+		item: testbenchItem,
+		target: testbench,
+	});
+	return testbenchItem;
+}
+
+async function runTestbenches(
+	controller: vscode.TestController,
+	runnableTestbenchesByItemId: Map<string, RunnableTestbenchItem>,
+	runService: TestbenchRunService,
+	outputChannel: vscode.OutputChannel,
+	request: vscode.TestRunRequest,
+	token: vscode.CancellationToken,
+): Promise<void> {
+	if (controller.items.size === 0) {
+		await controller.resolveHandler?.(undefined);
+	}
+
+	const run = controller.createTestRun(request, 'HDL Dev Testbenches');
+	const requested = collectRequestedTestbenches(
+		controller,
+		runnableTestbenchesByItemId,
+		request,
+	);
+
+	try {
+		for (const skipped of requested.skipped) {
+			run.skipped(skipped.item);
+		}
+
+		if (requested.runnable.length === 0) {
+			run.appendOutput('No HDL Dev testbenches selected.\r\n');
+			return;
+		}
+
+		for (const runnable of requested.runnable) {
+			run.enqueued(runnable.item);
+		}
+
+		const configuration = vscode.workspace.getConfiguration('hdlDev');
+		const makeExecutable = configuration.get<string>('makeExecutable', 'make');
+		const defaultStopTime = configuration.get<string>('defaultStopTime', '500us');
+		const defaultWaveFormat = configuration.get<string>('defaultWaveFormat', 'ghw');
+		const toolchainRoot = configuration.get<string>('toolchainRoot', '').trim();
+
+		for (const runnable of requested.runnable) {
+			if (token.isCancellationRequested || run.token.isCancellationRequested) {
+				run.skipped(runnable.item);
+				continue;
+			}
+
+			const abortController = new AbortController();
+			const cancellationSubscriptions = [
+				token.onCancellationRequested(() => abortController.abort()),
+				run.token.onCancellationRequested(() => abortController.abort()),
+			];
+
+			if (token.isCancellationRequested || run.token.isCancellationRequested) {
+				abortController.abort();
+			}
+
+			try {
+				run.started(runnable.item);
+				const result = await runService.runTestbench(runnable.target, {
+					workspaceTrusted: vscode.workspace.isTrusted,
+					makeExecutable,
+					defaultStopTime,
+					defaultWaveFormat,
+					environmentOverrides: toolchainRoot === '' ? {} : { GHDL_TOOLCHAIN_ROOT: toolchainRoot },
+					output: outputChannel,
+					cancellationSignal: abortController.signal,
+					onOutput: (chunk) => run.appendOutput(toTestOutput(chunk), undefined, runnable.item),
+				});
+				applyTestbenchRunResult(run, runnable.item, result);
+			} finally {
+				for (const subscription of cancellationSubscriptions) {
+					subscription.dispose();
+				}
+			}
+		}
+	} finally {
+		run.end();
+	}
+}
+
+function collectRequestedTestbenches(
+	controller: vscode.TestController,
+	runnableTestbenchesByItemId: Map<string, RunnableTestbenchItem>,
+	request: vscode.TestRunRequest,
+): {
+	readonly runnable: readonly RunnableTestbenchItem[];
+	readonly skipped: readonly RunnableTestbenchItem[];
+} {
+	const excludedIds = collectExcludedIds(request.exclude ?? []);
+	const includedItems = request.include ?? Array.from(controller.items, ([, item]) => item);
+	const runnableById = new Map<string, RunnableTestbenchItem>();
+	const skippedById = new Map<string, RunnableTestbenchItem>();
+
+	for (const item of includedItems) {
+		collectRunnableTestbenches(
+			item,
+			runnableTestbenchesByItemId,
+			excludedIds,
+			runnableById,
+			skippedById,
+		);
+	}
+
+	return {
+		runnable: Array.from(runnableById.values()),
+		skipped: Array.from(skippedById.values()),
+	};
+}
+
+function collectRunnableTestbenches(
+	item: vscode.TestItem,
+	runnableTestbenchesByItemId: Map<string, RunnableTestbenchItem>,
+	excludedIds: ReadonlySet<string>,
+	runnableById: Map<string, RunnableTestbenchItem>,
+	skippedById: Map<string, RunnableTestbenchItem>,
+): void {
+	const runnable = runnableTestbenchesByItemId.get(item.id);
+
+	if (runnable !== undefined) {
+		if (excludedIds.has(item.id)) {
+			skippedById.set(item.id, runnable);
+		} else {
+			runnableById.set(item.id, runnable);
+		}
+		return;
+	}
+
+	item.children.forEach((child) => {
+		collectRunnableTestbenches(
+			child,
+			runnableTestbenchesByItemId,
+			excludedIds,
+			runnableById,
+			skippedById,
+		);
+	});
+}
+
+function collectExcludedIds(items: readonly vscode.TestItem[]): ReadonlySet<string> {
+	const ids = new Set<string>();
+
+	for (const item of items) {
+		collectTestItemIds(item, ids);
+	}
+
+	return ids;
+}
+
+function collectTestItemIds(item: vscode.TestItem, ids: Set<string>): void {
+	ids.add(item.id);
+	item.children.forEach((child) => collectTestItemIds(child, ids));
+}
+
+function applyTestbenchRunResult(
+	run: vscode.TestRun,
+	item: vscode.TestItem,
+	result: TestbenchRunResult,
+): void {
+	switch (result.outcome) {
+		case 'passed':
+			run.passed(item, result.durationMs);
+			return;
+		case 'failed':
+			run.failed(item, new vscode.TestMessage(result.message), result.durationMs);
+			return;
+		case 'errored':
+		case 'blocked':
+			run.errored(item, new vscode.TestMessage(result.message), result.durationMs);
+			return;
+		case 'cancelled':
+			run.skipped(item);
+			return;
+	}
+}
+
+function toTestOutput(chunk: string): string {
+	return chunk.replace(/\r?\n/g, '\r\n');
 }
 
 function createProjectItemId(projectRootPath: string): string {

--- a/src/testbench/testbenchRun.ts
+++ b/src/testbench/testbenchRun.ts
@@ -1,0 +1,302 @@
+import {
+	buildTestbenchDiscoveryEnvironment,
+	nodeTestbenchProcessRunner,
+	type DiscoveredTestbench,
+	type TestbenchProcessRequest,
+	type TestbenchProcessRunner,
+} from './testbenchDiscovery';
+
+export const testbenchRunExecution = {
+	mode: 'make-test',
+	executedWorkspaceCommands: true,
+	requiresWorkspaceTrust: true,
+} as const;
+
+export type TestbenchWaveFormat = 'ghw' | 'fst' | 'vcd';
+
+export type TestbenchRunOutcome =
+	| 'passed'
+	| 'failed'
+	| 'errored'
+	| 'blocked'
+	| 'cancelled';
+
+export interface TestbenchRunOutput {
+	append(value: string): void;
+	appendLine(value: string): void;
+	show(preserveFocus?: boolean): void;
+}
+
+export interface TestbenchRunOptions {
+	readonly workspaceTrusted: boolean;
+	readonly makeExecutable?: string;
+	readonly defaultStopTime?: string;
+	readonly defaultWaveFormat?: string;
+	readonly env?: NodeJS.ProcessEnv;
+	readonly environmentOverrides?: NodeJS.ProcessEnv;
+	readonly output: TestbenchRunOutput;
+	readonly runner?: TestbenchProcessRunner;
+	readonly cancellationSignal?: AbortSignal;
+	readonly onOutput?: (chunk: string) => void;
+}
+
+export type TestbenchRunTarget = DiscoveredTestbench;
+
+export interface TestbenchRunResult {
+	readonly outcome: TestbenchRunOutcome;
+	readonly execution: typeof testbenchRunExecution;
+	readonly target: TestbenchRunTarget;
+	readonly command?: TestbenchProcessRequest;
+	readonly exitCode?: number;
+	readonly signal?: NodeJS.Signals;
+	readonly durationMs: number;
+	readonly rawOutput: {
+		readonly stdout: string;
+		readonly stderr: string;
+	};
+	readonly message: string;
+}
+
+const defaultMakeExecutable = 'make';
+const defaultStopTime = '500us';
+const defaultWaveFormat: TestbenchWaveFormat = 'ghw';
+const supportedWaveFormats = new Set<string>(['ghw', 'fst', 'vcd']);
+
+export class TestbenchRunService {
+	private readonly queuesByProjectRoot = new Map<string, Promise<void>>();
+
+	public runTestbench(
+		target: TestbenchRunTarget,
+		options: TestbenchRunOptions,
+	): Promise<TestbenchRunResult> {
+		const previousRun = this.queuesByProjectRoot.get(target.projectRootPath) ?? Promise.resolve();
+		const run = previousRun
+			.catch(() => undefined)
+			.then(() => this.runTestbenchNow(target, options));
+		const queueTail = run.then(() => undefined, () => undefined);
+		this.queuesByProjectRoot.set(target.projectRootPath, queueTail);
+		void queueTail.finally(() => {
+			if (this.queuesByProjectRoot.get(target.projectRootPath) === queueTail) {
+				this.queuesByProjectRoot.delete(target.projectRootPath);
+			}
+		});
+		return run;
+	}
+
+	private async runTestbenchNow(
+		target: TestbenchRunTarget,
+		options: TestbenchRunOptions,
+	): Promise<TestbenchRunResult> {
+		const startedAt = Date.now();
+		const rawOutput = {
+			stdout: '',
+			stderr: '',
+		};
+
+		options.output.show(true);
+		writeRunHeader(options.output, target);
+
+		if (!options.workspaceTrusted) {
+			const message = 'Workspace trust is required before HDL Dev can run Make targets.';
+			options.output.appendLine(`[error] ${message}`);
+			return createRunResult('blocked', target, rawOutput, startedAt, message);
+		}
+
+		if (isCancellationRequested(options.cancellationSignal)) {
+			const message = `Cancelled testbench run for ${target.name}`;
+			options.output.appendLine(`[cancelled] ${message}`);
+			return createRunResult('cancelled', target, rawOutput, startedAt, message);
+		}
+
+		const request = buildTestbenchRunRequest(target, options);
+		const runner = options.runner ?? nodeTestbenchProcessRunner;
+		writeRunExecutionDetails(options.output, target, request);
+
+		try {
+			const processResult = await runner.run(request, {
+				onStdout: (chunk) => {
+					rawOutput.stdout += chunk;
+					options.output.append(chunk);
+					options.onOutput?.(chunk);
+				},
+				onStderr: (chunk) => {
+					rawOutput.stderr += chunk;
+					options.output.append(chunk);
+					options.onOutput?.(chunk);
+				},
+			});
+
+			if (processResult.signal !== undefined || isCancellationRequested(options.cancellationSignal)) {
+				const message = `Cancelled testbench run for ${target.name}`;
+				options.output.appendLine('');
+				options.output.appendLine(`[cancelled] ${message}`);
+				return createRunResult(
+					'cancelled',
+					target,
+					rawOutput,
+					startedAt,
+					message,
+					request,
+					processResult.exitCode,
+					processResult.signal,
+				);
+			}
+
+			if (processResult.exitCode === 0) {
+				const message = `Testbench ${target.name} passed`;
+				options.output.appendLine('');
+				options.output.appendLine(`[ok] ${message}`);
+				return createRunResult(
+					'passed',
+					target,
+					rawOutput,
+					startedAt,
+					message,
+					request,
+					processResult.exitCode,
+				);
+			}
+
+			const message = `make test failed for ${target.name} with exit code ${processResult.exitCode}`;
+			options.output.appendLine('');
+			options.output.appendLine(`[error] ${message}`);
+			return createRunResult(
+				'failed',
+				target,
+				rawOutput,
+				startedAt,
+				message,
+				request,
+				processResult.exitCode,
+			);
+		} catch (error) {
+			if (isAbortError(error) || isCancellationRequested(options.cancellationSignal)) {
+				const message = `Cancelled testbench run for ${target.name}`;
+				options.output.appendLine('');
+				options.output.appendLine(`[cancelled] ${message}`);
+				return createRunResult(
+					'cancelled',
+					target,
+					rawOutput,
+					startedAt,
+					message,
+					request,
+				);
+			}
+
+			const message = `Failed to run testbench ${target.name}: ${errorMessage(error)}`;
+			options.output.appendLine('');
+			options.output.appendLine(`[error] ${message}`);
+			return createRunResult(
+				'errored',
+				target,
+				rawOutput,
+				startedAt,
+				message,
+				request,
+			);
+		}
+	}
+}
+
+export function buildTestbenchRunRequest(
+	target: TestbenchRunTarget,
+	options: Pick<
+		TestbenchRunOptions,
+		| 'makeExecutable'
+		| 'defaultStopTime'
+		| 'defaultWaveFormat'
+		| 'env'
+		| 'environmentOverrides'
+		| 'cancellationSignal'
+	>,
+): TestbenchProcessRequest {
+	return {
+		executablePath: normalizeMakeExecutable(options.makeExecutable),
+		args: [
+			'test',
+			`TB=${target.name}`,
+			`STOP_TIME=${normalizeStopTime(options.defaultStopTime)}`,
+			`WAVE_FORMAT=${normalizeWaveFormat(options.defaultWaveFormat)}`,
+		],
+		cwd: target.projectRootPath,
+		env: buildTestbenchDiscoveryEnvironment(
+			options.env ?? process.env,
+			options.environmentOverrides ?? {},
+		),
+		signal: options.cancellationSignal,
+	};
+}
+
+function createRunResult(
+	outcome: TestbenchRunOutcome,
+	target: TestbenchRunTarget,
+	rawOutput: TestbenchRunResult['rawOutput'],
+	startedAt: number,
+	message: string,
+	command?: TestbenchProcessRequest,
+	exitCode?: number,
+	signal?: NodeJS.Signals,
+): TestbenchRunResult {
+	return {
+		outcome,
+		execution: testbenchRunExecution,
+		target,
+		command,
+		exitCode,
+		signal,
+		durationMs: Date.now() - startedAt,
+		rawOutput,
+		message,
+	};
+}
+
+function normalizeMakeExecutable(makeExecutable: string | undefined): string {
+	const trimmed = makeExecutable?.trim() ?? '';
+	return trimmed === '' ? defaultMakeExecutable : trimmed;
+}
+
+function normalizeStopTime(stopTime: string | undefined): string {
+	const trimmed = stopTime?.trim() ?? '';
+	return trimmed === '' ? defaultStopTime : trimmed;
+}
+
+function normalizeWaveFormat(waveFormat: string | undefined): TestbenchWaveFormat {
+	const trimmed = waveFormat?.trim() ?? '';
+	return supportedWaveFormats.has(trimmed) ? trimmed as TestbenchWaveFormat : defaultWaveFormat;
+}
+
+function writeRunHeader(output: TestbenchRunOutput, target: TestbenchRunTarget): void {
+	output.appendLine('');
+	output.appendLine('[HDL Dev] Running GHDL testbench');
+	output.appendLine('[HDL Dev] Profile: testbench-run');
+	output.appendLine(`[HDL Dev] Testbench: ${target.name}`);
+}
+
+function writeRunExecutionDetails(
+	output: TestbenchRunOutput,
+	target: TestbenchRunTarget,
+	request: TestbenchProcessRequest,
+): void {
+	output.appendLine(`[HDL Dev] Project root: ${target.projectRootPath}`);
+	output.appendLine(`[HDL Dev] Executable: ${request.executablePath}`);
+	output.appendLine(`[HDL Dev] Arguments: ${JSON.stringify(request.args)}`);
+	output.appendLine(`[HDL Dev] Working directory: ${request.cwd}`);
+	output.appendLine('');
+}
+
+function isAbortError(error: unknown): boolean {
+	return error instanceof Error && error.name === 'AbortError';
+}
+
+function isCancellationRequested(signal: AbortSignal | undefined): boolean {
+	return signal?.aborted === true;
+}
+
+function errorMessage(error: unknown): string {
+	if (error instanceof Error) {
+		return error.message;
+	}
+
+	return String(error);
+}


### PR DESCRIPTION
## Summary

Refs #5.

- Add a Make-backed testbench run service that invokes `make test TB=<name> STOP_TIME=<time> WAVE_FORMAT=<format>` with explicit process arguments.
- Wire the `HDL Dev Testbenches` controller to a default `Run Testbench` profile, including selection/exclusion handling, test result output streaming, cancellation, and per-project run serialization.
- Add `hdlDev.defaultStopTime` and `hdlDev.defaultWaveFormat` settings.
- Update the v0.2 workflow docs and README to describe discovery plus run support.

## Validation

- `npm run compile`
- `npm run lint`
- `git diff --check`
- `make docs-build`
- `XDG_RUNTIME_DIR=$(mktemp -d /tmp/hdl-dev-vscode-runtime-XXXXXX) npm test` - 26 passing

## Manual Fixture Transcript

Compiled run service against a temporary managed-style Makefile fixture with one passing and one failing testbench:

```text
[HDL Dev] Running GHDL testbench
[HDL Dev] Profile: testbench-run
[HDL Dev] Testbench: pass_tb
[HDL Dev] Project root: /tmp/hdl-dev-run-evidence-jXeW0G
[HDL Dev] Executable: make
[HDL Dev] Arguments: ["test","TB=pass_tb","STOP_TIME=2us","WAVE_FORMAT=vcd"]
[HDL Dev] Working directory: /tmp/hdl-dev-run-evidence-jXeW0G

running pass_tb stop=2us wave=vcd
completed pass_tb

[ok] Testbench pass_tb passed
[manual] pass_tb: outcome=passed exit=0

[HDL Dev] Running GHDL testbench
[HDL Dev] Profile: testbench-run
[HDL Dev] Testbench: fail_tb
[HDL Dev] Project root: /tmp/hdl-dev-run-evidence-jXeW0G
[HDL Dev] Executable: make
[HDL Dev] Arguments: ["test","TB=fail_tb","STOP_TIME=2us","WAVE_FORMAT=vcd"]
[HDL Dev] Working directory: /tmp/hdl-dev-run-evidence-jXeW0G

running fail_tb stop=2us wave=vcd
assertion failed in fail_tb
make: *** [Makefile:7: test] Error 2

[error] make test failed for fail_tb with exit code 2
[manual] fail_tb: outcome=failed exit=2
```

## Testing API Capture

The extension test run includes the new `Testbench Run` suite with command construction, pass/fail/error mapping, cancellation forwarding, trust blocking, and per-project serialization coverage. The VS Code Testing API surface is `HDL Dev Testbenches` with the default `Run Testbench` profile.