### PR TITLE
Document native testbench runner evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ Design notes live under `docs/` and are published through MkDocs:
 - [GEnCor Integration Notes](docs/integrations/gencor.md)
 - [v0.1 Project Discovery And Dependency Doctor](docs/workflows/v0.1-project-discovery-and-doctor.md)
 - [v0.2 Native Testbench Runner](docs/workflows/v0.2-testbench-discovery.md)
+- [v0.2 Native Testbench Runner Evidence](docs/workflows/v0.2-native-testbench-runner-evidence.md)
 - [Project Discovery](docs/design/project-discovery.md)
 - [Initial Extension Design](docs/design/initial-extension-design.md)
 - [MVP Roadmap](docs/design/mvp-roadmap.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,9 @@ repo's own extension-facing command-line workflow.
 - [v0.2 Native Testbench Runner](workflows/v0.2-testbench-discovery.md)
   describes the `make list-tbs` discovery contract, `make test` run contract,
   Testing API surface, trust behavior, and managed Makefile pattern.
+- [v0.2 Native Testbench Runner Evidence](workflows/v0.2-native-testbench-runner-evidence.md)
+  records the milestone evidence scope, test coverage, artifact expectations,
+  and manual transcript shape for closing v0.2.
 - [Initial Extension Design](design/initial-extension-design.md) describes the
   proposed feature areas, VS Code surfaces, and implementation boundaries.
 - [Project Discovery](design/project-discovery.md) documents the passive

--- a/docs/workflows/v0.2-native-testbench-runner-evidence.md
+++ b/docs/workflows/v0.2-native-testbench-runner-evidence.md
@@ -1,0 +1,118 @@
+# v0.2 Native Testbench Runner Evidence
+
+This page records the evidence scope for closing the v0.2 Native Testbench
+Runner milestone. The extension keeps project Makefiles as the source of truth
+and uses the VS Code Testing API as the native editor surface.
+
+## Shipped Scope
+
+v0.2 is split across three GitHub issues:
+
+- `#4`: discover GHDL testbenches with `make list-tbs`
+- `#5`: run testbenches with `make test TB=<name> STOP_TIME=<time> WAVE_FORMAT=<format>`
+- `#6`: collect and review milestone evidence
+
+Issues `#4` and `#5` are complete before this evidence gate closes.
+
+## User Workflow
+
+The Testing view resolves `HDL Dev Testbenches` on demand. Each discovered HDL
+project becomes a top-level test item, and each Make-reported testbench becomes
+a runnable child item.
+
+```text
+HDL Dev Testbenches
+  timer
+    timer_tb
+    uart_tb
+    fifo_tb
+```
+
+The default run profile is `Run Testbench`. Running a single child item invokes:
+
+```bash
+make test TB=<testbench> STOP_TIME=<time> WAVE_FORMAT=<ghw|fst|vcd>
+```
+
+Running a project item runs its discovered child testbenches. Runs that share a
+project root are serialized so they do not race in the same build directory.
+
+## Settings
+
+The shipped v0.2 settings are:
+
+- `hdlDev.projectRoots`: optional explicit HDL project roots
+- `hdlDev.makeExecutable`: Make executable path, defaulting to `make`
+- `hdlDev.defaultStopTime`: default `STOP_TIME`, defaulting to `500us`
+- `hdlDev.defaultWaveFormat`: default `WAVE_FORMAT`, defaulting to `ghw`
+- `hdlDev.toolchainRoot`: optional GHDL toolchain root
+
+`hdlDev.defaultWaveFormat` is constrained to `ghw`, `fst`, or `vcd`.
+
+## Artifact Expectations
+
+The project Makefile owns wave dump generation. For GEnCor-style projects, a
+testbench run is expected to write wave dumps under:
+
+```text
+build/waves/<testbench>.<format>
+```
+
+HDL Dev does not open or index those wave dumps in v0.2. It preserves the raw
+Make output in the test result output and the HDL Dev Output channel so users
+can see the exact command, working directory, exit status, and any artifact
+paths printed by the project.
+
+Artifact navigation is planned for the Artifact Explorer milestone.
+
+## Automated Coverage
+
+The extension test suite covers the v0.2 behavior in these suites:
+
+- `Testbench Discovery`: list parsing, process arguments, per-project
+  namespaces, empty and failed discovery, cancellation, slow discovery, in-flight
+  de-duplication, and managed-style Makefile fixtures
+- `Testbench Run`: command construction, pass/fail/error mapping, cancellation,
+  workspace trust blocking, per-project serialization, run settings, and default
+  setting normalization
+- `Project Discovery`: project-root and generated artifact directory detection
+
+The milestone evidence command set is:
+
+```bash
+npm run compile
+npm run lint
+git diff --check
+make docs-build
+XDG_RUNTIME_DIR=$(mktemp -d /tmp/hdl-dev-vscode-runtime-XXXXXX) npm test
+```
+
+## Manual Evidence
+
+The evidence gate uses a temporary managed-style Makefile fixture with one
+passing and one failing testbench. The expected transcript shape is:
+
+```text
+[HDL Dev] Running GHDL testbench
+[HDL Dev] Profile: testbench-run
+[HDL Dev] Testbench: pass_tb
+[HDL Dev] Arguments: ["test","TB=pass_tb","STOP_TIME=2us","WAVE_FORMAT=vcd"]
+
+running pass_tb stop=2us wave=vcd
+completed pass_tb
+
+[ok] Testbench pass_tb passed
+
+[HDL Dev] Running GHDL testbench
+[HDL Dev] Profile: testbench-run
+[HDL Dev] Testbench: fail_tb
+[HDL Dev] Arguments: ["test","TB=fail_tb","STOP_TIME=2us","WAVE_FORMAT=vcd"]
+
+running fail_tb stop=2us wave=vcd
+assertion failed in fail_tb
+
+[error] make test failed for fail_tb with exit code 2
+```
+
+The GitHub issue evidence comment carries the exact local transcript and remote
+workflow URLs used for final review.

--- a/docs/workflows/v0.2-testbench-discovery.md
+++ b/docs/workflows/v0.2-testbench-discovery.md
@@ -64,6 +64,20 @@ failed. Process launch errors are surfaced as test errors. Raw standard output
 and standard error are streamed into both the VS Code test result output and the
 HDL Dev Output channel.
 
+## Wave Artifacts
+
+The project Makefile owns simulator output locations. For GEnCor-style projects,
+the expected wave dump convention is:
+
+```text
+build/waves/<testbench>.<format>
+```
+
+The `<format>` suffix follows the `WAVE_FORMAT` argument, usually `ghw`, `fst`,
+or `vcd`. HDL Dev records the project root, command arguments, working
+directory, and raw command output so users can find artifacts even before the
+Artifact Explorer milestone adds first-class artifact navigation.
+
 ## VS Code Surface
 
 The extension registers an `HDL Dev Testbenches` TestController. Testbench
@@ -107,3 +121,10 @@ the same build directory. Different project roots can run independently.
   be added later if project scripts emit machine-readable output.
 - The extension does not generate or inject managed Makefiles. Shared recipe
   templates should be added as project-local files when needed.
+
+## Evidence
+
+The v0.2 milestone evidence page records the proof used to close the native
+testbench runner milestone:
+
+- [v0.2 Native Testbench Runner Evidence](v0.2-native-testbench-runner-evidence.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,6 +18,7 @@ nav:
   - Workflows:
       - v0.1 Project Discovery And Dependency Doctor: workflows/v0.1-project-discovery-and-doctor.md
       - v0.2 Native Testbench Runner: workflows/v0.2-testbench-discovery.md
+      - v0.2 Native Testbench Runner Evidence: workflows/v0.2-native-testbench-runner-evidence.md
   - Design:
       - Project Discovery: design/project-discovery.md
       - Initial Extension Design: design/initial-extension-design.md


### PR DESCRIPTION
## Summary

Refs #6.

- Add a v0.2 Native Testbench Runner evidence page covering shipped scope, Testing API surface, settings, artifact expectations, automated coverage, and manual evidence shape.
- Link the evidence page from the root README, docs index, MkDocs navigation, and the v0.2 workflow page.
- Document the `build/waves/<testbench>.<format>` wave artifact expectation while keeping Makefiles as the source of truth.

## Validation

- `npm run compile`
- `npm run lint`
- `git diff --check`
- `make docs-build`
- `XDG_RUNTIME_DIR=$(mktemp -d /tmp/hdl-dev-vscode-runtime-XXXXXX) npm test` - 26 passing

## Manual Fixture Transcript

Fresh local transcript from the compiled run service against a temporary managed-style Makefile fixture:

```text
[HDL Dev] Running GHDL testbench
[HDL Dev] Profile: testbench-run
[HDL Dev] Testbench: pass_tb
[HDL Dev] Project root: /tmp/hdl-dev-v02-evidence-CjXYxP
[HDL Dev] Executable: make
[HDL Dev] Arguments: ["test","TB=pass_tb","STOP_TIME=2us","WAVE_FORMAT=vcd"]
[HDL Dev] Working directory: /tmp/hdl-dev-v02-evidence-CjXYxP

running pass_tb stop=2us wave=vcd
wave artifact build/waves/pass_tb.vcd
completed pass_tb

[ok] Testbench pass_tb passed
[manual] pass_tb: outcome=passed exit=0

[HDL Dev] Running GHDL testbench
[HDL Dev] Profile: testbench-run
[HDL Dev] Testbench: fail_tb
[HDL Dev] Project root: /tmp/hdl-dev-v02-evidence-CjXYxP
[HDL Dev] Executable: make
[HDL Dev] Arguments: ["test","TB=fail_tb","STOP_TIME=2us","WAVE_FORMAT=vcd"]
[HDL Dev] Working directory: /tmp/hdl-dev-v02-evidence-CjXYxP

running fail_tb stop=2us wave=vcd
wave artifact build/waves/fail_tb.vcd
assertion failed in fail_tb
make: *** [Makefile:10: test] Error 2

[error] make test failed for fail_tb with exit code 2
[manual] fail_tb: outcome=failed exit=2
[artifact] fail_tb.vcd
[artifact] pass_tb.vcd
```

## Testing API Capture

The evidence page records the visible Testing API surface as:

```text
HDL Dev Testbenches
  timer
    timer_tb
    uart_tb
    fifo_tb
```

Default run profile: `Run Testbench`. Automated coverage verifies command construction, pass/fail/error state mapping, cancellation forwarding, trust blocking, settings, and per-project serialization.