### PR TITLE
Add Specs tree view (#7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 HDL Dev is a VS Code extension for coordinating HDL project workflows from
 inside the editor. The project is currently an early TypeScript extension with
 passive HDL project discovery, dependency-check commands, testbench discovery,
-testbench run support, documentation, CI, and GitHub Pages infrastructure in
-place.
+testbench run support, Specs tree navigation, documentation, CI, and GitHub
+Pages infrastructure in place.
 
 The design direction is to keep HDL project scripts as the source of truth and
 wrap them with native VS Code surfaces: commands, Output channels, the Testing
@@ -13,8 +13,8 @@ API, tree views, status items, and focused artifact previews.
 ## Features
 
 Current shipped extension behavior covers the v0.1 Project Discovery and
-Dependency Doctor milestone plus the v0.2 native testbench discovery and run
-implementation slices.
+Dependency Doctor milestone, the v0.2 native testbench discovery and run
+implementation slices, and the first v0.3 Specs tree slice.
 
 Feature status:
 
@@ -32,8 +32,10 @@ Feature status:
 - [x] dependency status bar item
 - [x] VS Code Testing API testbench discovery
 - [x] VS Code Testing API testbench run support
-- [ ] waveform spec tree and SVG generation commands
-- [ ] schematic spec tree and SVG generation commands
+- [x] HDL Activity Bar view container
+- [x] waveform and schematic Specs tree
+- [ ] waveform SVG generation commands
+- [ ] schematic SVG generation commands
 - [ ] generated artifact explorer
 - [ ] waveform and schematic JSON schemas
 - [ ] `ghwdump -H` signal picker for waveform specs
@@ -42,6 +44,7 @@ Feature status:
 
 Shipped command names use the `HDL Dev` prefix:
 
+- `HDL Dev: Refresh Specs`
 - `HDL Dev: Check GHDL Dependencies`
 - `HDL Dev: Check Documentation Asset Dependencies`
 
@@ -152,10 +155,9 @@ generation.
   shell output; JSON output is planned for more reliable extension integration.
 - Dependency Doctor commands are blocked until the workspace is trusted.
 - Testbench result status is currently based on Make process exit status.
-- Spec trees, artifact navigation, previews, schemas, and packetized-I/O debug
-  helpers are planned but not implemented yet.
-- Waveform and schematic generation are documented as design targets but are not
-  implemented in the extension yet.
+- Spec schema validation, generation commands, artifact navigation, previews,
+  and packetized-I/O debug helpers are planned but not implemented yet.
+- Waveform and schematic generation remain documented design targets.
 
 ## Release Notes
 
@@ -181,6 +183,7 @@ Design notes live under `docs/` and are published through MkDocs:
 - [v0.1 Project Discovery And Dependency Doctor](docs/workflows/v0.1-project-discovery-and-doctor.md)
 - [v0.2 Native Testbench Runner](docs/workflows/v0.2-testbench-discovery.md)
 - [v0.2 Native Testbench Runner Evidence](docs/workflows/v0.2-native-testbench-runner-evidence.md)
+- [v0.3 Specs Tree](docs/workflows/v0.3-specs-tree.md)
 - [Project Discovery](docs/design/project-discovery.md)
 - [Initial Extension Design](docs/design/initial-extension-design.md)
 - [MVP Roadmap](docs/design/mvp-roadmap.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,9 @@ repo's own extension-facing command-line workflow.
 - [v0.2 Native Testbench Runner Evidence](workflows/v0.2-native-testbench-runner-evidence.md)
   records the milestone evidence scope, test coverage, artifact expectations,
   and manual transcript shape for closing v0.2.
+- [v0.3 Specs Tree](workflows/v0.3-specs-tree.md) describes the HDL view
+  container, Specs tree grouping, refresh behavior, context values, and
+  invalid-JSON handling.
 - [Initial Extension Design](design/initial-extension-design.md) describes the
   proposed feature areas, VS Code surfaces, and implementation boundaries.
 - [Project Discovery](design/project-discovery.md) documents the passive

--- a/docs/workflows/v0.3-specs-tree.md
+++ b/docs/workflows/v0.3-specs-tree.md
@@ -1,0 +1,103 @@
+# v0.3 Specs Tree
+
+HDL Dev exposes waveform and schematic spec files through a native VS Code tree.
+The extension still treats repo-local project files as the source of truth: it
+does not generate or rewrite specs during discovery.
+
+## Discovery Contract
+
+The Specs tree uses the passive HDL project discovery model. A project is
+eligible when it has a `Makefile` and at least one spec directory:
+
+```text
+docs/waveforms/specs
+docs/schematics/specs
+```
+
+Spec discovery reads `.json` files directly from those directories:
+
+```text
+docs/waveforms/specs/*.json
+docs/schematics/specs/*.json
+```
+
+The scan parses each file with JSON parsing only. It does not validate waveform
+or schematic schema semantics yet.
+
+## VS Code Surface
+
+The extension contributes an Activity Bar view container named `HDL` and a
+`Specs` view under it. The view is shown when passive discovery finds at least
+one HDL project.
+
+The manual refresh command is:
+
+```text
+HDL Dev: Refresh Specs
+```
+
+The same refresh is also wired to workspace folder changes, `hdlDev.projectRoots`
+configuration changes, and file create/change/delete events below either spec
+directory.
+
+## Tree Shape
+
+The tree groups specs first by project, then by spec kind:
+
+```text
+HDL
+  Specs
+    timer
+      Waveform Specs
+        timer-wave.json
+      Schematic Specs
+        timer-schematic.json
+        broken.json  Invalid JSON
+```
+
+Project item labels use the project directory name and include the absolute
+project root as description and tooltip. Spec item IDs include the project root,
+spec kind, and absolute spec path so IDs remain stable across tree refreshes for
+the same checkout.
+
+## Context Values
+
+Tree items expose context values for later command contributions:
+
+```text
+hdlDev.specs.project
+hdlDev.specs.kind.waveform
+hdlDev.specs.kind.schematic
+hdlDev.specs.spec.waveform.valid
+hdlDev.specs.spec.waveform.invalid
+hdlDev.specs.spec.schematic.valid
+hdlDev.specs.spec.schematic.invalid
+hdlDev.specs.status.empty
+hdlDev.specs.status.error
+```
+
+Valid and invalid spec items both open their JSON file with the normal VS Code
+editor when selected.
+
+## Empty And Error States
+
+If no HDL projects are found, the tree reports an empty state with the expected
+project shape. If a project has a spec directory but no `.json` files, the
+corresponding kind group reports an empty state.
+
+Invalid JSON does not block the tree. The affected file is listed with an
+invalid context value, a warning icon, and a tooltip containing the parse error
+so the user can open and fix only that file.
+
+## Trust
+
+Spec discovery is passive file reading. It does not run Make, Python, GHDL,
+Yosys, `netlistsvg`, or project scripts, so it is allowed before the workspace
+is trusted. Generation commands remain future trust-sensitive work.
+
+## Current Limits
+
+- Schema-level waveform and schematic validation is not implemented yet.
+- SVG generation commands are not implemented in this slice.
+- Generated SVG and intermediate artifact navigation are deferred to later
+  Specs and Artifact Explorer work.

--- a/media/hdl.svg
+++ b/media/hdl.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+  <path fill="currentColor" d="M5 4h14v16H5V4Zm2 2v12h10V6H7Zm2 2h2v2H9V8Zm4 0h2v2h-2V8Zm-4 4h2v2H9v-2Zm4 0h2v2h-2v-2Z"/>
+  <path fill="currentColor" d="M2 8h3v2H2V8Zm0 6h3v2H2v-2Zm17-6h3v2h-3V8Zm0 6h3v2h-3v-2Z"/>
+</svg>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,6 +19,7 @@ nav:
       - v0.1 Project Discovery And Dependency Doctor: workflows/v0.1-project-discovery-and-doctor.md
       - v0.2 Native Testbench Runner: workflows/v0.2-testbench-discovery.md
       - v0.2 Native Testbench Runner Evidence: workflows/v0.2-native-testbench-runner-evidence.md
+      - v0.3 Specs Tree: workflows/v0.3-specs-tree.md
   - Design:
       - Project Discovery: design/project-discovery.md
       - Initial Extension Design: design/initial-extension-design.md

--- a/package.json
+++ b/package.json
@@ -11,12 +11,19 @@
   ],
   "activationEvents": [
     "onStartupFinished",
+    "onView:vscode-hdl-dev.specs",
+    "onCommand:vscode-hdl-dev.refreshSpecs",
     "onCommand:vscode-hdl-dev.checkGhdlDependencies",
     "onCommand:vscode-hdl-dev.checkDocsAssetDependencies"
   ],
   "main": "./out/extension.js",
   "contributes": {
     "commands": [
+      {
+        "command": "vscode-hdl-dev.refreshSpecs",
+        "title": "Refresh Specs",
+        "category": "HDL Dev"
+      },
       {
         "command": "vscode-hdl-dev.checkGhdlDependencies",
         "title": "Check GHDL Dependencies",
@@ -70,6 +77,33 @@
           "description": "Optional GHDL toolchain root. When set, HDL Dev passes it as GHDL_TOOLCHAIN_ROOT and prepends its bin directory to PATH."
         }
       }
+    },
+    "viewsContainers": {
+      "activitybar": [
+        {
+          "id": "hdlDev",
+          "title": "HDL",
+          "icon": "media/hdl.svg"
+        }
+      ]
+    },
+    "views": {
+      "hdlDev": [
+        {
+          "id": "vscode-hdl-dev.specs",
+          "name": "Specs",
+          "when": "hdlDev.hasProjects"
+        }
+      ]
+    },
+    "menus": {
+      "view/title": [
+        {
+          "command": "vscode-hdl-dev.refreshSpecs",
+          "when": "view == vscode-hdl-dev.specs",
+          "group": "navigation"
+        }
+      ]
     }
   },
   "scripts": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,6 +9,7 @@ import {
 	type DependencyCheckProfile,
 	type DependencyCheckStatus,
 } from './doctor/dependencyDoctor';
+import { registerSpecsTree } from './specs/specsTree';
 import { registerTestbenchController } from './testbench/testbenchController';
 
 export function activate(context: vscode.ExtensionContext) {
@@ -25,6 +26,7 @@ export function activate(context: vscode.ExtensionContext) {
 	};
 
 	statusSink.setStatus(createUnknownDependencyStatus());
+	registerSpecsTree(context);
 	registerTestbenchController(context, outputChannel);
 
 	const runDoctorCommand = async (profile: DependencyCheckProfile): Promise<void> => {

--- a/src/specs/specDiscovery.ts
+++ b/src/specs/specDiscovery.ts
@@ -1,0 +1,184 @@
+import type { Dirent } from 'node:fs';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+
+import {
+	discoverHdlProjects,
+	passiveDiscoveryExecution,
+	type HdlProjectModel,
+} from '../discovery/projectDiscovery';
+
+export const specDiscoveryExecution = passiveDiscoveryExecution;
+
+export type SpecKind = 'waveform' | 'schematic';
+export type SpecStatus = 'valid' | 'invalid';
+export type SpecDiscoveryOutcome = 'discovered' | 'empty' | 'noProjects';
+
+export interface SpecDiscoveryOptions {
+	readonly workspaceFolderPaths: readonly string[];
+	readonly configuredRootPaths?: readonly string[];
+	readonly projects?: readonly HdlProjectModel[];
+}
+
+export interface DiscoveredSpec {
+	readonly id: string;
+	readonly kind: SpecKind;
+	readonly status: SpecStatus;
+	readonly name: string;
+	readonly fileName: string;
+	readonly filePath: string;
+	readonly projectRootPath: string;
+	readonly relativePath: string;
+	readonly errorMessage?: string;
+}
+
+export interface ProjectSpecDiscoveryResult {
+	readonly project: HdlProjectModel;
+	readonly specs: Record<SpecKind, readonly DiscoveredSpec[]>;
+}
+
+export interface SpecDiscoveryResult {
+	readonly outcome: SpecDiscoveryOutcome;
+	readonly discovery: typeof specDiscoveryExecution;
+	readonly projects: readonly ProjectSpecDiscoveryResult[];
+	readonly message: string;
+}
+
+export async function discoverWorkspaceSpecs(
+	options: SpecDiscoveryOptions,
+): Promise<SpecDiscoveryResult> {
+	const projects = options.projects ?? (await discoverHdlProjects({
+		workspaceFolderPaths: options.workspaceFolderPaths,
+		configuredRootPaths: options.configuredRootPaths,
+	})).projects;
+
+	if (projects.length === 0) {
+		return {
+			outcome: 'noProjects',
+			discovery: specDiscoveryExecution,
+			projects: [],
+			message: 'No HDL projects were found for spec discovery.',
+		};
+	}
+
+	const projectResults = await Promise.all(
+		projects.map(async (project) => discoverProjectSpecs(project)),
+	);
+	const sortedProjectResults = projectResults
+		.sort((left, right) => left.project.rootPath.localeCompare(right.project.rootPath));
+	const specCount = sortedProjectResults.reduce((count, projectResult) => (
+		count
+			+ projectResult.specs.waveform.length
+			+ projectResult.specs.schematic.length
+	), 0);
+
+	if (specCount === 0) {
+		return {
+			outcome: 'empty',
+			discovery: specDiscoveryExecution,
+			projects: sortedProjectResults,
+			message: 'No waveform or schematic spec JSON files were found.',
+		};
+	}
+
+	return {
+		outcome: 'discovered',
+		discovery: specDiscoveryExecution,
+		projects: sortedProjectResults,
+		message: `Discovered ${specCount} HDL spec${specCount === 1 ? '' : 's'}.`,
+	};
+}
+
+export function createSpecItemId(
+	projectRootPath: string,
+	kind: SpecKind,
+	filePath: string,
+): string {
+	return [
+		'hdl-dev.spec',
+		kind,
+		path.resolve(projectRootPath),
+		path.resolve(filePath),
+	].join('|');
+}
+
+async function discoverProjectSpecs(
+	project: HdlProjectModel,
+): Promise<ProjectSpecDiscoveryResult> {
+	const specs = {
+		waveform: await discoverSpecsForKind(project, 'waveform'),
+		schematic: await discoverSpecsForKind(project, 'schematic'),
+	};
+
+	return {
+		project,
+		specs,
+	};
+}
+
+async function discoverSpecsForKind(
+	project: HdlProjectModel,
+	kind: SpecKind,
+): Promise<readonly DiscoveredSpec[]> {
+	const capability = project.specs[kind];
+
+	if (!capability.available) {
+		return [];
+	}
+
+	const entries = await readDirectoryEntries(capability.path);
+	const jsonFiles = entries
+		.filter((entry) => entry.isFile() && entry.name.endsWith('.json'))
+		.map((entry) => path.join(capability.path, entry.name))
+		.sort((left, right) => left.localeCompare(right));
+
+	return Promise.all(
+		jsonFiles.map(async (filePath) => readSpecFile(project.rootPath, kind, filePath)),
+	);
+}
+
+async function readSpecFile(
+	projectRootPath: string,
+	kind: SpecKind,
+	filePath: string,
+): Promise<DiscoveredSpec> {
+	const commonFields = {
+		id: createSpecItemId(projectRootPath, kind, filePath),
+		kind,
+		name: path.basename(filePath, '.json'),
+		fileName: path.basename(filePath),
+		filePath,
+		projectRootPath,
+		relativePath: path.relative(projectRootPath, filePath),
+	};
+
+	try {
+		JSON.parse(await fs.readFile(filePath, 'utf8'));
+		return {
+			...commonFields,
+			status: 'valid',
+		};
+	} catch (error) {
+		return {
+			...commonFields,
+			status: 'invalid',
+			errorMessage: formatJsonError(error),
+		};
+	}
+}
+
+async function readDirectoryEntries(directoryPath: string): Promise<Dirent[]> {
+	try {
+		return await fs.readdir(directoryPath, { withFileTypes: true });
+	} catch {
+		return [];
+	}
+}
+
+function formatJsonError(error: unknown): string {
+	if (error instanceof Error) {
+		return `Invalid JSON: ${error.message.replace(/\s+/g, ' ')}`;
+	}
+
+	return 'Invalid JSON: unable to parse file.';
+}

--- a/src/specs/specsTree.ts
+++ b/src/specs/specsTree.ts
@@ -1,0 +1,374 @@
+import * as path from 'node:path';
+
+import * as vscode from 'vscode';
+
+import {
+	discoverWorkspaceSpecs,
+	type DiscoveredSpec,
+	type ProjectSpecDiscoveryResult,
+	type SpecDiscoveryOptions,
+	type SpecDiscoveryResult,
+	type SpecKind,
+} from './specDiscovery';
+
+export const specsTreeViewId = 'vscode-hdl-dev.specs';
+export const refreshSpecsCommand = 'vscode-hdl-dev.refreshSpecs';
+export const hasHdlProjectsContext = 'hdlDev.hasProjects';
+
+export type SpecsTreeNode =
+	| SpecsTreeProjectNode
+	| SpecsTreeKindNode
+	| SpecsTreeSpecNode
+	| SpecsTreeStatusNode;
+
+export interface SpecsTreeProjectNode {
+	readonly type: 'project';
+	readonly projectResult: ProjectSpecDiscoveryResult;
+}
+
+export interface SpecsTreeKindNode {
+	readonly type: 'kind';
+	readonly projectResult: ProjectSpecDiscoveryResult;
+	readonly kind: SpecKind;
+}
+
+export interface SpecsTreeSpecNode {
+	readonly type: 'spec';
+	readonly spec: DiscoveredSpec;
+}
+
+export interface SpecsTreeStatusNode {
+	readonly type: 'status';
+	readonly id: string;
+	readonly label: string;
+	readonly description?: string;
+	readonly contextValue: string;
+	readonly severity: 'info' | 'warning' | 'error';
+}
+
+type ContextSetter = (key: string, value: boolean) => Thenable<unknown>;
+
+export function registerSpecsTree(context: vscode.ExtensionContext): void {
+	const provider = new SpecsTreeDataProvider(
+		createWorkspaceSpecDiscoveryOptions,
+		(key, value) => vscode.commands.executeCommand('setContext', key, value),
+	);
+	const refresh = (): void => {
+		void provider.refresh();
+	};
+	const view = vscode.window.createTreeView(specsTreeViewId, {
+		treeDataProvider: provider,
+		showCollapseAll: true,
+	});
+	const watcherDisposables = createSpecFileWatchers(refresh);
+
+	context.subscriptions.push(
+		provider,
+		view,
+		...watcherDisposables,
+		vscode.commands.registerCommand(refreshSpecsCommand, async () => provider.refresh()),
+		vscode.workspace.onDidChangeWorkspaceFolders(refresh),
+		vscode.workspace.onDidChangeConfiguration((event) => {
+			if (event.affectsConfiguration('hdlDev.projectRoots')) {
+				refresh();
+			}
+		}),
+	);
+
+	refresh();
+}
+
+export class SpecsTreeDataProvider implements vscode.TreeDataProvider<SpecsTreeNode>, vscode.Disposable {
+	private readonly onDidChangeTreeDataEmitter = new vscode.EventEmitter<SpecsTreeNode | undefined | null | void>();
+	public readonly onDidChangeTreeData = this.onDidChangeTreeDataEmitter.event;
+	private result: SpecDiscoveryResult | undefined;
+	private refreshError: string | undefined;
+	private refreshSequence = 0;
+
+	public constructor(
+		private readonly optionsProvider: () => SpecDiscoveryOptions,
+		private readonly setContext: ContextSetter,
+	) {}
+
+	public async refresh(): Promise<void> {
+		const sequence = ++this.refreshSequence;
+
+		try {
+			const result = await discoverWorkspaceSpecs(this.optionsProvider());
+
+			if (sequence !== this.refreshSequence) {
+				return;
+			}
+
+			this.result = result;
+			this.refreshError = undefined;
+			await this.setContext(hasHdlProjectsContext, result.projects.length > 0);
+		} catch (error) {
+			if (sequence !== this.refreshSequence) {
+				return;
+			}
+
+			this.result = undefined;
+			this.refreshError = formatRefreshError(error);
+			await this.setContext(hasHdlProjectsContext, false);
+		} finally {
+			if (sequence === this.refreshSequence) {
+				this.onDidChangeTreeDataEmitter.fire();
+			}
+		}
+	}
+
+	public getTreeItem(element: SpecsTreeNode): vscode.TreeItem {
+		return createSpecsTreeItem(element);
+	}
+
+	public getChildren(element?: SpecsTreeNode): vscode.ProviderResult<SpecsTreeNode[]> {
+		if (element === undefined) {
+			return createSpecsTreeRootNodes(this.result, this.refreshError);
+		}
+
+		if (element.type === 'project') {
+			return createProjectChildren(element.projectResult);
+		}
+
+		if (element.type === 'kind') {
+			return createKindChildren(element.projectResult, element.kind);
+		}
+
+		return [];
+	}
+
+	public dispose(): void {
+		this.onDidChangeTreeDataEmitter.dispose();
+	}
+}
+
+export function createSpecsTreeRootNodes(
+	result: SpecDiscoveryResult | undefined,
+	refreshError?: string,
+): SpecsTreeNode[] {
+	if (refreshError !== undefined) {
+		return [{
+			type: 'status',
+			id: 'hdl-dev.specs.status.discovery-error',
+			label: 'Unable to discover HDL specs',
+			description: refreshError,
+			contextValue: 'hdlDev.specs.status.error',
+			severity: 'error',
+		}];
+	}
+
+	if (result === undefined) {
+		return [{
+			type: 'status',
+			id: 'hdl-dev.specs.status.loading',
+			label: 'Discovering HDL specs',
+			contextValue: 'hdlDev.specs.status.loading',
+			severity: 'info',
+		}];
+	}
+
+	if (result.projects.length === 0) {
+		return [{
+			type: 'status',
+			id: 'hdl-dev.specs.status.no-projects',
+			label: 'No HDL projects found',
+			description: 'Add a Makefile and spec directory, then refresh.',
+			contextValue: 'hdlDev.specs.status.empty',
+			severity: 'info',
+		}];
+	}
+
+	return result.projects.map((projectResult) => ({
+		type: 'project',
+		projectResult,
+	}));
+}
+
+export function createSpecsTreeItem(element: SpecsTreeNode): vscode.TreeItem {
+	if (element.type === 'project') {
+		return createProjectTreeItem(element.projectResult);
+	}
+
+	if (element.type === 'kind') {
+		return createKindTreeItem(element.projectResult, element.kind);
+	}
+
+	if (element.type === 'spec') {
+		return createSpecTreeItem(element.spec);
+	}
+
+	return createStatusTreeItem(element);
+}
+
+function createProjectChildren(projectResult: ProjectSpecDiscoveryResult): SpecsTreeNode[] {
+	const children: SpecsTreeNode[] = [];
+
+	if (projectResult.project.specs.waveform.available) {
+		children.push({
+			type: 'kind',
+			projectResult,
+			kind: 'waveform',
+		});
+	}
+
+	if (projectResult.project.specs.schematic.available) {
+		children.push({
+			type: 'kind',
+			projectResult,
+			kind: 'schematic',
+		});
+	}
+
+	if (children.length === 0) {
+		children.push({
+			type: 'status',
+			id: `${createProjectNodeId(projectResult.project.rootPath)}|empty`,
+			label: 'No spec directories found',
+			description: 'Expected docs/waveforms/specs or docs/schematics/specs.',
+			contextValue: 'hdlDev.specs.status.empty',
+			severity: 'info',
+		});
+	}
+
+	return children;
+}
+
+function createKindChildren(
+	projectResult: ProjectSpecDiscoveryResult,
+	kind: SpecKind,
+): SpecsTreeNode[] {
+	const specs = projectResult.specs[kind];
+
+	if (specs.length > 0) {
+		return specs.map((spec) => ({
+			type: 'spec',
+			spec,
+		}));
+	}
+
+	return [{
+		type: 'status',
+		id: `${createKindNodeId(projectResult.project.rootPath, kind)}|empty`,
+		label: `No ${formatKindLabel(kind).toLowerCase()} JSON files found`,
+		description: 'Create a .json file in this spec directory, then refresh.',
+		contextValue: 'hdlDev.specs.status.empty',
+		severity: 'info',
+	}];
+}
+
+function createProjectTreeItem(projectResult: ProjectSpecDiscoveryResult): vscode.TreeItem {
+	const project = projectResult.project;
+	const item = new vscode.TreeItem(path.basename(project.rootPath), vscode.TreeItemCollapsibleState.Expanded);
+	item.id = createProjectNodeId(project.rootPath);
+	item.description = project.rootPath;
+	item.tooltip = project.rootPath;
+	item.contextValue = 'hdlDev.specs.project';
+	item.resourceUri = vscode.Uri.file(project.rootPath);
+	item.iconPath = new vscode.ThemeIcon('root-folder');
+	return item;
+}
+
+function createKindTreeItem(
+	projectResult: ProjectSpecDiscoveryResult,
+	kind: SpecKind,
+): vscode.TreeItem {
+	const specs = projectResult.specs[kind];
+	const item = new vscode.TreeItem(`${formatKindLabel(kind)} Specs`, vscode.TreeItemCollapsibleState.Expanded);
+	item.id = createKindNodeId(projectResult.project.rootPath, kind);
+	item.description = `${specs.length}`;
+	item.tooltip = `${formatKindLabel(kind)} specs in ${projectResult.project.rootPath}`;
+	item.contextValue = `hdlDev.specs.kind.${kind}`;
+	item.iconPath = new vscode.ThemeIcon('folder');
+	return item;
+}
+
+function createSpecTreeItem(spec: DiscoveredSpec): vscode.TreeItem {
+	const item = new vscode.TreeItem(spec.fileName, vscode.TreeItemCollapsibleState.None);
+	item.id = spec.id;
+	item.description = spec.status === 'valid' ? spec.relativePath : 'Invalid JSON';
+	item.tooltip = spec.status === 'valid'
+		? spec.filePath
+		: `${spec.filePath}\n${spec.errorMessage ?? 'Invalid JSON'}`;
+	item.contextValue = `hdlDev.specs.spec.${spec.kind}.${spec.status}`;
+	item.resourceUri = vscode.Uri.file(spec.filePath);
+	item.command = {
+		command: 'vscode.open',
+		title: 'Open Spec',
+		arguments: [vscode.Uri.file(spec.filePath)],
+	};
+	item.iconPath = spec.status === 'valid'
+		? new vscode.ThemeIcon('file-code')
+		: new vscode.ThemeIcon('warning', new vscode.ThemeColor('problemsWarningIcon.foreground'));
+	return item;
+}
+
+function createStatusTreeItem(node: SpecsTreeStatusNode): vscode.TreeItem {
+	const item = new vscode.TreeItem(node.label, vscode.TreeItemCollapsibleState.None);
+	item.id = node.id;
+	item.description = node.description;
+	item.tooltip = node.description ?? node.label;
+	item.contextValue = node.contextValue;
+	item.iconPath = new vscode.ThemeIcon(statusIconId(node.severity));
+	return item;
+}
+
+function createSpecFileWatchers(refresh: () => void): vscode.Disposable[] {
+	const disposables: vscode.Disposable[] = [];
+
+	for (const pattern of [
+		'**/docs/waveforms/specs/*.json',
+		'**/docs/schematics/specs/*.json',
+	]) {
+		const watcher = vscode.workspace.createFileSystemWatcher(pattern);
+		disposables.push(
+			watcher,
+			watcher.onDidCreate(refresh),
+			watcher.onDidChange(refresh),
+			watcher.onDidDelete(refresh),
+		);
+	}
+
+	return disposables;
+}
+
+function createWorkspaceSpecDiscoveryOptions(): SpecDiscoveryOptions {
+	const configuration = vscode.workspace.getConfiguration('hdlDev');
+
+	return {
+		workspaceFolderPaths: vscode.workspace.workspaceFolders?.map((folder) => folder.uri.fsPath) ?? [],
+		configuredRootPaths: configuration.get<readonly string[]>('projectRoots', []),
+	};
+}
+
+function createProjectNodeId(projectRootPath: string): string {
+	return `hdl-dev.specs.project|${projectRootPath}`;
+}
+
+function createKindNodeId(projectRootPath: string, kind: SpecKind): string {
+	return `hdl-dev.specs.kind|${projectRootPath}|${kind}`;
+}
+
+function formatKindLabel(kind: SpecKind): string {
+	return kind === 'waveform' ? 'Waveform' : 'Schematic';
+}
+
+function statusIconId(severity: SpecsTreeStatusNode['severity']): string {
+	if (severity === 'error') {
+		return 'error';
+	}
+
+	if (severity === 'warning') {
+		return 'warning';
+	}
+
+	return 'info';
+}
+
+function formatRefreshError(error: unknown): string {
+	if (error instanceof Error) {
+		return error.message;
+	}
+
+	return 'Unknown spec discovery error.';
+}

--- a/src/test/dependencyDoctor.test.ts
+++ b/src/test/dependencyDoctor.test.ts
@@ -180,13 +180,9 @@ suite('Dependency Doctor', () => {
 			};
 		};
 
-		assert.deepStrictEqual(
-			packageJson.contributes.commands.map((command) => command.command).sort(),
-			[
-				checkDocsAssetDependenciesCommand,
-				checkGhdlDependenciesCommand,
-			].sort(),
-		);
+		const commandIds = packageJson.contributes.commands.map((command) => command.command);
+		assert.ok(commandIds.includes(checkDocsAssetDependenciesCommand));
+		assert.ok(commandIds.includes(checkGhdlDependenciesCommand));
 		assert.ok(packageJson.contributes.commands.every((command) => command.category === 'HDL Dev'));
 	});
 });

--- a/src/test/specDiscovery.test.ts
+++ b/src/test/specDiscovery.test.ts
@@ -1,0 +1,160 @@
+import * as assert from 'node:assert';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import {
+	createSpecItemId,
+	discoverWorkspaceSpecs,
+	specDiscoveryExecution,
+} from '../specs/specDiscovery';
+
+const tempRoots: string[] = [];
+
+suite('Spec Discovery', () => {
+	teardown(async () => {
+		await Promise.all(tempRoots.splice(0).map(async (tempRoot) => {
+			await fs.rm(tempRoot, { recursive: true, force: true });
+		}));
+	});
+
+	test('discovers waveform and schematic spec JSON files with stable IDs', async () => {
+		const workspacePath = await createTempWorkspace();
+		const projectPath = path.join(workspacePath, 'pcores', 'timer');
+		await createHdlProject(projectPath, {
+			waveformSpecs: [{
+				fileName: 'timer-wave.json',
+				content: '{ "signals": [] }\n',
+			}],
+			schematicSpecs: [{
+				fileName: 'timer-schematic.json',
+				content: '{ "modules": [] }\n',
+			}],
+		});
+
+		const result = await discoverWorkspaceSpecs({
+			workspaceFolderPaths: [workspacePath],
+		});
+
+		assert.strictEqual(result.outcome, 'discovered');
+		assert.deepStrictEqual(result.discovery, specDiscoveryExecution);
+		assert.strictEqual(result.projects.length, 1);
+
+		const [projectResult] = result.projects;
+		const [waveformSpec] = projectResult.specs.waveform;
+		const [schematicSpec] = projectResult.specs.schematic;
+
+		assert.strictEqual(projectResult.project.rootPath, projectPath);
+		assert.strictEqual(waveformSpec.status, 'valid');
+		assert.strictEqual(waveformSpec.kind, 'waveform');
+		assert.strictEqual(waveformSpec.name, 'timer-wave');
+		assert.strictEqual(
+			waveformSpec.id,
+			createSpecItemId(projectPath, 'waveform', waveformSpec.filePath),
+		);
+		assert.strictEqual(schematicSpec.status, 'valid');
+		assert.strictEqual(schematicSpec.kind, 'schematic');
+		assert.strictEqual(
+			schematicSpec.id,
+			createSpecItemId(projectPath, 'schematic', schematicSpec.filePath),
+		);
+	});
+
+	test('keeps valid specs when one spec contains invalid JSON', async () => {
+		const workspacePath = await createTempWorkspace();
+		const projectPath = path.join(workspacePath, 'cores', 'uart');
+		await createHdlProject(projectPath, {
+			waveformSpecs: [{
+				fileName: 'uart-wave.json',
+				content: '{ "signals": [] }\n',
+			}],
+			schematicSpecs: [{
+				fileName: 'broken.json',
+				content: '{ "modules": [ }\n',
+			}],
+		});
+
+		const result = await discoverWorkspaceSpecs({
+			workspaceFolderPaths: [workspacePath],
+		});
+
+		assert.strictEqual(result.outcome, 'discovered');
+		assert.strictEqual(result.projects.length, 1);
+		assert.strictEqual(result.projects[0].specs.waveform[0].status, 'valid');
+		assert.strictEqual(result.projects[0].specs.schematic[0].status, 'invalid');
+		assert.match(result.projects[0].specs.schematic[0].errorMessage ?? '', /Invalid JSON/);
+	});
+
+	test('reports empty projects when spec directories contain no JSON files', async () => {
+		const workspacePath = await createTempWorkspace();
+		const projectPath = path.join(workspacePath, 'pcores', 'empty');
+		await createHdlProject(projectPath, {
+			waveformSpecs: [],
+			schematicSpecs: [],
+		});
+
+		const result = await discoverWorkspaceSpecs({
+			workspaceFolderPaths: [workspacePath],
+		});
+
+		assert.strictEqual(result.outcome, 'empty');
+		assert.strictEqual(result.projects.length, 1);
+		assert.deepStrictEqual(result.projects[0].specs.waveform, []);
+		assert.deepStrictEqual(result.projects[0].specs.schematic, []);
+	});
+});
+
+interface SpecFixture {
+	readonly fileName: string;
+	readonly content: string;
+}
+
+interface HdlSpecProjectFixtureOptions {
+	readonly waveformSpecs?: readonly SpecFixture[];
+	readonly schematicSpecs?: readonly SpecFixture[];
+}
+
+async function createTempWorkspace(): Promise<string> {
+	const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'hdl-dev-specs-'));
+	tempRoots.push(tempRoot);
+	return tempRoot;
+}
+
+async function createHdlProject(
+	projectPath: string,
+	options: HdlSpecProjectFixtureOptions,
+): Promise<void> {
+	await writeFixtureFile(path.join(projectPath, 'Makefile'), [
+		'list-tbs:',
+		'\t@printf "timer_tb\\n"',
+		'',
+	].join('\n'));
+	await writeSpecFixtures(
+		path.join(projectPath, 'docs', 'waveforms', 'specs'),
+		options.waveformSpecs,
+	);
+	await writeSpecFixtures(
+		path.join(projectPath, 'docs', 'schematics', 'specs'),
+		options.schematicSpecs,
+	);
+}
+
+async function writeSpecFixtures(
+	directoryPath: string,
+	specs: readonly SpecFixture[] | undefined,
+): Promise<void> {
+	if (specs === undefined) {
+		return;
+	}
+
+	await fs.mkdir(directoryPath, { recursive: true });
+
+	for (const spec of specs) {
+		await writeFixtureFile(path.join(directoryPath, spec.fileName), spec.content);
+	}
+}
+
+async function writeFixtureFile(filePath: string, content: string): Promise<void> {
+	await fs.mkdir(path.dirname(filePath), { recursive: true });
+	await fs.writeFile(filePath, content, 'utf8');
+}

--- a/src/test/specsTree.test.ts
+++ b/src/test/specsTree.test.ts
@@ -1,0 +1,209 @@
+import * as assert from 'node:assert';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+
+import {
+	passiveDiscoveryExecution,
+	type HdlProjectModel,
+	type ProjectCapability,
+} from '../discovery/projectDiscovery';
+import {
+	createSpecItemId,
+	type DiscoveredSpec,
+	type ProjectSpecDiscoveryResult,
+} from '../specs/specDiscovery';
+import {
+	createSpecsTreeItem,
+	createSpecsTreeRootNodes,
+	hasHdlProjectsContext,
+	refreshSpecsCommand,
+	SpecsTreeDataProvider,
+	specsTreeViewId,
+	type SpecsTreeNode,
+} from '../specs/specsTree';
+
+suite('Specs Tree', () => {
+	test('creates project, kind, valid spec, and invalid spec tree items', () => {
+		const projectResult = createProjectSpecDiscoveryResult();
+		const [validSpec] = projectResult.specs.waveform;
+		const [invalidSpec] = projectResult.specs.schematic;
+
+		const projectItem = createSpecsTreeItem({
+			type: 'project',
+			projectResult,
+		});
+		const kindItem = createSpecsTreeItem({
+			type: 'kind',
+			projectResult,
+			kind: 'waveform',
+		});
+		const validSpecItem = createSpecsTreeItem({
+			type: 'spec',
+			spec: validSpec,
+		});
+		const invalidSpecItem = createSpecsTreeItem({
+			type: 'spec',
+			spec: invalidSpec,
+		});
+
+		assert.strictEqual(projectItem.label, 'timer');
+		assert.strictEqual(projectItem.contextValue, 'hdlDev.specs.project');
+		assert.strictEqual(kindItem.label, 'Waveform Specs');
+		assert.strictEqual(kindItem.description, '1');
+		assert.strictEqual(kindItem.contextValue, 'hdlDev.specs.kind.waveform');
+		assert.strictEqual(validSpecItem.id, validSpec.id);
+		assert.strictEqual(validSpecItem.contextValue, 'hdlDev.specs.spec.waveform.valid');
+		assert.strictEqual(validSpecItem.command?.command, 'vscode.open');
+		assert.strictEqual(invalidSpecItem.description, 'Invalid JSON');
+		assert.strictEqual(invalidSpecItem.contextValue, 'hdlDev.specs.spec.schematic.invalid');
+		assert.match(String(invalidSpecItem.tooltip), /Invalid JSON/);
+	});
+
+	test('creates empty state nodes when there are no projects', () => {
+		const nodes = createSpecsTreeRootNodes({
+			outcome: 'noProjects',
+			discovery: passiveDiscoveryExecution,
+			projects: [],
+			message: 'No HDL projects were found for spec discovery.',
+		});
+
+		assert.strictEqual(nodes.length, 1);
+		assert.strictEqual(nodes[0].type, 'status');
+		assert.strictEqual(nodes[0].contextValue, 'hdlDev.specs.status.empty');
+	});
+
+	test('refresh sets the HDL project context before exposing project roots', async () => {
+		const projectResult = createProjectSpecDiscoveryResult();
+		const contextValues: Array<{ readonly key: string; readonly value: boolean }> = [];
+		const provider = new SpecsTreeDataProvider(
+			() => ({
+				workspaceFolderPaths: [],
+				projects: [projectResult.project],
+			}),
+			async (key, value) => {
+				contextValues.push({ key, value });
+			},
+		);
+
+		await provider.refresh();
+		const rootNodes = provider.getChildren() as SpecsTreeNode[];
+
+		assert.deepStrictEqual(contextValues, [{
+			key: hasHdlProjectsContext,
+			value: true,
+		}]);
+		assert.strictEqual(rootNodes.length, 1);
+		assert.strictEqual(rootNodes[0].type, 'project');
+		provider.dispose();
+	});
+
+	test('package contributes HDL container, Specs view, and refresh command', async () => {
+		const packageJsonPath = path.join(__dirname, '..', '..', 'package.json');
+		const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf8')) as {
+			contributes: {
+				commands: Array<{ readonly command: string; readonly category?: string }>;
+				viewsContainers: {
+					activitybar: Array<{ readonly id: string; readonly title: string; readonly icon: string }>;
+				};
+				views: Record<string, Array<{ readonly id: string; readonly name: string; readonly when?: string }>>;
+				menus: {
+					'view/title': Array<{ readonly command: string; readonly when: string }>;
+				};
+			};
+		};
+
+		assert.ok(packageJson.contributes.commands.some((command) => (
+			command.command === refreshSpecsCommand && command.category === 'HDL Dev'
+		)));
+		assert.ok(packageJson.contributes.viewsContainers.activitybar.some((container) => (
+			container.id === 'hdlDev'
+				&& container.title === 'HDL'
+				&& container.icon === 'media/hdl.svg'
+		)));
+		assert.ok(packageJson.contributes.views.hdlDev.some((view) => (
+			view.id === specsTreeViewId
+				&& view.name === 'Specs'
+				&& view.when === hasHdlProjectsContext
+		)));
+		assert.ok(packageJson.contributes.menus['view/title'].some((menu) => (
+			menu.command === refreshSpecsCommand
+				&& menu.when === `view == ${specsTreeViewId}`
+		)));
+	});
+});
+
+function createProjectSpecDiscoveryResult(): ProjectSpecDiscoveryResult {
+	const project = createHdlProjectModel('/workspace/timer');
+	const waveformSpec = createDiscoveredSpec(project.rootPath, 'waveform', 'timer-wave.json', 'valid');
+	const schematicSpec = createDiscoveredSpec(project.rootPath, 'schematic', 'broken.json', 'invalid');
+	return {
+		project,
+		specs: {
+			waveform: [waveformSpec],
+			schematic: [schematicSpec],
+		},
+	};
+}
+
+function createDiscoveredSpec(
+	projectRootPath: string,
+	kind: DiscoveredSpec['kind'],
+	fileName: string,
+	status: DiscoveredSpec['status'],
+): DiscoveredSpec {
+	const specDirectory = kind === 'waveform'
+		? path.join('docs', 'waveforms', 'specs')
+		: path.join('docs', 'schematics', 'specs');
+	const filePath = path.join(projectRootPath, specDirectory, fileName);
+
+	return {
+		id: createSpecItemId(projectRootPath, kind, filePath),
+		kind,
+		status,
+		name: path.basename(fileName, '.json'),
+		fileName,
+		filePath,
+		projectRootPath,
+		relativePath: path.relative(projectRootPath, filePath),
+		errorMessage: status === 'invalid' ? 'Invalid JSON: Unexpected token' : undefined,
+	};
+}
+
+function createHdlProjectModel(rootPath: string): HdlProjectModel {
+	return {
+		rootPath,
+		makefilePath: path.join(rootPath, 'Makefile'),
+		sources: ['workspaceFolder'],
+		workspaceFolderPaths: ['/workspace'],
+		dependencyScript: capability(rootPath, path.join('scripts', 'deps.sh'), false),
+		specs: {
+			waveform: capability(rootPath, path.join('docs', 'waveforms', 'specs'), true),
+			schematic: capability(rootPath, path.join('docs', 'schematics', 'specs'), true),
+		},
+		buildDirectories: {
+			ghdl: capability(rootPath, path.join('build', 'ghdl'), false),
+			waves: capability(rootPath, path.join('build', 'waves'), false),
+			schematics: capability(rootPath, path.join('build', 'schematics'), false),
+			csv: capability(rootPath, path.join('build', 'csv'), false),
+		},
+		artifactDirectories: {
+			waveformSvgs: capability(rootPath, path.join('docs', 'waveforms', 'generated'), false),
+			schematicSvgs: capability(rootPath, path.join('docs', 'schematics', 'generated'), false),
+			logs: capability(rootPath, 'logs', false),
+			plots: capability(rootPath, path.join('logs', 'plots'), false),
+		},
+		discovery: passiveDiscoveryExecution,
+	};
+}
+
+function capability(
+	rootPath: string,
+	relativePath: string,
+	available: boolean,
+): ProjectCapability {
+	return {
+		available,
+		path: path.join(rootPath, relativePath),
+		status: available ? 'present' : 'missingOptionalDirectory',
+	};
+}


### PR DESCRIPTION
## Summary

Refs #7.

- Add passive waveform/schematic spec discovery from `docs/waveforms/specs/*.json` and `docs/schematics/specs/*.json`, including stable IDs and invalid-JSON reporting.
- Contribute the `HDL` Activity Bar container, `Specs` tree view, refresh command, file watchers, empty states, and context values for later commands.
- Document the v0.3 Specs tree workflow and cover discovery/tree item behavior in automated tests.

## Validation

- `npm run compile`
- `npm run lint`
- `make docs-build`
- `git diff --check`
- `XDG_RUNTIME_DIR=$(mktemp -d /tmp/hdl-dev-vscode-runtime-XXXXXX) npm test` - 33 passing

## Fixture Capture

```text
HDL
  Specs
    timer
      Waveform Specs
        timer-wave.json
      Schematic Specs
        broken.json  Invalid JSON: Unexpected token '}', "{ "modules": [ } " is not valid JSON
        timer-schematic.json
```

## Remote Checks

- Git Flow Policy: https://github.com/cosgroma/vscode-hdl-dev/actions/runs/24636814585
- CI: https://github.com/cosgroma/vscode-hdl-dev/actions/runs/24636814589
- Pages: https://github.com/cosgroma/vscode-hdl-dev/actions/runs/24636814595
- Doctor GHDL Smoke: https://github.com/cosgroma/vscode-hdl-dev/actions/runs/24636814601