### PR TITLE
Add spec SVG generation commands (#8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ API, tree views, status items, and focused artifact previews.
 
 Current shipped extension behavior covers the v0.1 Project Discovery and
 Dependency Doctor milestone, the v0.2 native testbench discovery and run
-implementation slices, and the first v0.3 Specs tree slice.
+implementation slices, and the first v0.3 Specs tree and SVG generation
+slices.
 
 Feature status:
 
@@ -34,8 +35,8 @@ Feature status:
 - [x] VS Code Testing API testbench run support
 - [x] HDL Activity Bar view container
 - [x] waveform and schematic Specs tree
-- [ ] waveform SVG generation commands
-- [ ] schematic SVG generation commands
+- [x] waveform SVG generation commands
+- [x] schematic SVG generation commands
 - [ ] generated artifact explorer
 - [ ] waveform and schematic JSON schemas
 - [ ] `ghwdump -H` signal picker for waveform specs
@@ -45,6 +46,9 @@ Feature status:
 Shipped command names use the `HDL Dev` prefix:
 
 - `HDL Dev: Refresh Specs`
+- `HDL Dev: Generate Waveform SVG`
+- `HDL Dev: Generate Waveform SVG Without Rerun`
+- `HDL Dev: Generate Schematic SVG`
 - `HDL Dev: Check GHDL Dependencies`
 - `HDL Dev: Check Documentation Asset Dependencies`
 
@@ -55,8 +59,6 @@ Shipped Testing API surface:
 
 Planned command names:
 
-- `HDL Dev: Generate Waveform SVG`
-- `HDL Dev: Generate Schematic SVG`
 - `HDL Dev: Open Latest Artifact`
 
 ## Requirements
@@ -155,9 +157,10 @@ generation.
   shell output; JSON output is planned for more reliable extension integration.
 - Dependency Doctor commands are blocked until the workspace is trusted.
 - Testbench result status is currently based on Make process exit status.
-- Spec schema validation, generation commands, artifact navigation, previews,
-  and packetized-I/O debug helpers are planned but not implemented yet.
-- Waveform and schematic generation remain documented design targets.
+- Spec schema validation, artifact navigation, previews, and packetized-I/O
+  debug helpers are planned but not implemented yet.
+- Waveform and schematic generation status is based on Make process exit status
+  plus a generated-SVG existence check.
 
 ## Release Notes
 

--- a/docs/workflows/v0.3-specs-tree.md
+++ b/docs/workflows/v0.3-specs-tree.md
@@ -30,7 +30,7 @@ The extension contributes an Activity Bar view container named `HDL` and a
 `Specs` view under it. The view is shown when passive discovery finds at least
 one HDL project.
 
-The manual refresh command is:
+The Specs view exposes the manual refresh command:
 
 ```text
 HDL Dev: Refresh Specs
@@ -62,7 +62,7 @@ the same checkout.
 
 ## Context Values
 
-Tree items expose context values for later command contributions:
+Tree items expose context values for command contributions:
 
 ```text
 hdlDev.specs.project
@@ -77,7 +77,44 @@ hdlDev.specs.status.error
 ```
 
 Valid and invalid spec items both open their JSON file with the normal VS Code
-editor when selected.
+editor when selected. Valid spec items also expose generation actions in the
+Specs tree context menu.
+
+## Generation Commands
+
+Waveform specs expose:
+
+```text
+HDL Dev: Generate Waveform SVG
+HDL Dev: Generate Waveform SVG Without Rerun
+```
+
+Schematic specs expose:
+
+```text
+HDL Dev: Generate Schematic SVG
+```
+
+The commands invoke the project Makefile from the project root with explicit
+process arguments:
+
+```text
+make docs-waveforms WAVEFORM=<spec-name>
+make docs-waveforms WAVEFORM=<spec-name> NO_RUN=1
+make docs-schematics SCHEMATIC=<spec-name>
+```
+
+The extension preserves standard output and standard error in the HDL Dev
+Output channel. After a successful Make exit, HDL Dev verifies the expected SVG
+exists and opens it in the editor:
+
+```text
+docs/waveforms/generated/<spec-name>.svg
+docs/schematics/generated/<spec-name>.svg
+```
+
+If Make exits successfully but the SVG is missing, the command reports the
+expected artifact path as an actionable error.
 
 ## Empty And Error States
 
@@ -93,11 +130,14 @@ so the user can open and fix only that file.
 
 Spec discovery is passive file reading. It does not run Make, Python, GHDL,
 Yosys, `netlistsvg`, or project scripts, so it is allowed before the workspace
-is trusted. Generation commands remain future trust-sensitive work.
+is trusted.
+
+SVG generation commands are workspace commands. They are blocked until the
+workspace is trusted, and generation is serialized per project root so waveform
+and schematic commands do not race in a shared build directory.
 
 ## Current Limits
 
 - Schema-level waveform and schematic validation is not implemented yet.
-- SVG generation commands are not implemented in this slice.
 - Generated SVG and intermediate artifact navigation are deferred to later
   Specs and Artifact Explorer work.

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
   "activationEvents": [
     "onStartupFinished",
     "onView:vscode-hdl-dev.specs",
+    "onCommand:vscode-hdl-dev.generateWaveformSvg",
+    "onCommand:vscode-hdl-dev.generateWaveformSvgNoRun",
+    "onCommand:vscode-hdl-dev.generateSchematicSvg",
     "onCommand:vscode-hdl-dev.refreshSpecs",
     "onCommand:vscode-hdl-dev.checkGhdlDependencies",
     "onCommand:vscode-hdl-dev.checkDocsAssetDependencies"
@@ -19,6 +22,21 @@
   "main": "./out/extension.js",
   "contributes": {
     "commands": [
+      {
+        "command": "vscode-hdl-dev.generateWaveformSvg",
+        "title": "Generate Waveform SVG",
+        "category": "HDL Dev"
+      },
+      {
+        "command": "vscode-hdl-dev.generateWaveformSvgNoRun",
+        "title": "Generate Waveform SVG Without Rerun",
+        "category": "HDL Dev"
+      },
+      {
+        "command": "vscode-hdl-dev.generateSchematicSvg",
+        "title": "Generate Schematic SVG",
+        "category": "HDL Dev"
+      },
       {
         "command": "vscode-hdl-dev.refreshSpecs",
         "title": "Refresh Specs",
@@ -102,6 +120,23 @@
           "command": "vscode-hdl-dev.refreshSpecs",
           "when": "view == vscode-hdl-dev.specs",
           "group": "navigation"
+        }
+      ],
+      "view/item/context": [
+        {
+          "command": "vscode-hdl-dev.generateWaveformSvg",
+          "when": "view == vscode-hdl-dev.specs && viewItem == hdlDev.specs.spec.waveform.valid",
+          "group": "navigation@1"
+        },
+        {
+          "command": "vscode-hdl-dev.generateWaveformSvgNoRun",
+          "when": "view == vscode-hdl-dev.specs && viewItem == hdlDev.specs.spec.waveform.valid",
+          "group": "navigation@2"
+        },
+        {
+          "command": "vscode-hdl-dev.generateSchematicSvg",
+          "when": "view == vscode-hdl-dev.specs && viewItem == hdlDev.specs.spec.schematic.valid",
+          "group": "navigation@1"
         }
       ]
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,6 +9,7 @@ import {
 	type DependencyCheckProfile,
 	type DependencyCheckStatus,
 } from './doctor/dependencyDoctor';
+import { registerSpecGenerationCommands } from './specs/specGenerationCommands';
 import { registerSpecsTree } from './specs/specsTree';
 import { registerTestbenchController } from './testbench/testbenchController';
 
@@ -27,6 +28,7 @@ export function activate(context: vscode.ExtensionContext) {
 
 	statusSink.setStatus(createUnknownDependencyStatus());
 	registerSpecsTree(context);
+	registerSpecGenerationCommands(context, outputChannel);
 	registerTestbenchController(context, outputChannel);
 
 	const runDoctorCommand = async (profile: DependencyCheckProfile): Promise<void> => {

--- a/src/specs/specGeneration.ts
+++ b/src/specs/specGeneration.ts
@@ -1,0 +1,395 @@
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+
+import {
+	buildTestbenchDiscoveryEnvironment,
+	nodeTestbenchProcessRunner,
+	type TestbenchProcessRequest,
+	type TestbenchProcessRunner,
+} from '../testbench/testbenchDiscovery';
+import type { DiscoveredSpec } from './specDiscovery';
+
+export const specGenerationExecution = {
+	mode: 'make-docs-spec-svg',
+	executedWorkspaceCommands: true,
+	requiresWorkspaceTrust: true,
+} as const;
+
+export type SpecGenerationMode =
+	| 'waveform'
+	| 'waveformNoRun'
+	| 'schematic';
+
+export type SpecGenerationOutcome =
+	| 'generated'
+	| 'failed'
+	| 'errored'
+	| 'blocked'
+	| 'cancelled'
+	| 'invalidTarget'
+	| 'missingArtifact';
+
+export interface SpecGenerationOutput {
+	append(value: string): void;
+	appendLine(value: string): void;
+	show(preserveFocus?: boolean): void;
+}
+
+export interface SpecGenerationOptions {
+	readonly workspaceTrusted: boolean;
+	readonly makeExecutable?: string;
+	readonly env?: NodeJS.ProcessEnv;
+	readonly environmentOverrides?: NodeJS.ProcessEnv;
+	readonly output: SpecGenerationOutput;
+	readonly runner?: TestbenchProcessRunner;
+	readonly cancellationSignal?: AbortSignal;
+	readonly artifactExists?: (artifactPath: string) => Promise<boolean>;
+}
+
+export interface SpecGenerationTarget {
+	readonly spec: DiscoveredSpec;
+	readonly mode: SpecGenerationMode;
+}
+
+export interface SpecGenerationResult {
+	readonly outcome: SpecGenerationOutcome;
+	readonly execution: typeof specGenerationExecution;
+	readonly target: SpecGenerationTarget;
+	readonly command?: TestbenchProcessRequest;
+	readonly exitCode?: number;
+	readonly signal?: NodeJS.Signals;
+	readonly durationMs: number;
+	readonly artifactPath: string;
+	readonly rawOutput: {
+		readonly stdout: string;
+		readonly stderr: string;
+	};
+	readonly message: string;
+}
+
+const defaultMakeExecutable = 'make';
+
+export class SpecGenerationService {
+	private readonly queuesByProjectRoot = new Map<string, Promise<void>>();
+
+	public generateSpecSvg(
+		target: SpecGenerationTarget,
+		options: SpecGenerationOptions,
+	): Promise<SpecGenerationResult> {
+		const projectRootPath = target.spec.projectRootPath;
+		const previousRun = this.queuesByProjectRoot.get(projectRootPath) ?? Promise.resolve();
+		const run = previousRun
+			.catch(() => undefined)
+			.then(() => this.generateSpecSvgNow(target, options));
+		const queueTail = run.then(() => undefined, () => undefined);
+		this.queuesByProjectRoot.set(projectRootPath, queueTail);
+		void queueTail.finally(() => {
+			if (this.queuesByProjectRoot.get(projectRootPath) === queueTail) {
+				this.queuesByProjectRoot.delete(projectRootPath);
+			}
+		});
+		return run;
+	}
+
+	private async generateSpecSvgNow(
+		target: SpecGenerationTarget,
+		options: SpecGenerationOptions,
+	): Promise<SpecGenerationResult> {
+		const startedAt = Date.now();
+		const rawOutput = {
+			stdout: '',
+			stderr: '',
+		};
+		const artifactPath = getGeneratedSvgPath(target.spec);
+
+		options.output.show(true);
+		writeGenerationHeader(options.output, target);
+
+		if (!options.workspaceTrusted) {
+			const message = 'Workspace trust is required before HDL Dev can run Make targets.';
+			options.output.appendLine(`[error] ${message}`);
+			return createGenerationResult('blocked', target, artifactPath, rawOutput, startedAt, message);
+		}
+
+		if (target.spec.status !== 'valid') {
+			const message = `Cannot generate SVG for invalid JSON spec ${target.spec.fileName}.`;
+			options.output.appendLine(`[error] ${message}`);
+			return createGenerationResult('invalidTarget', target, artifactPath, rawOutput, startedAt, message);
+		}
+
+		if (!isModeCompatibleWithSpec(target)) {
+			const message = `Cannot run ${formatModeLabel(target.mode)} for ${target.spec.kind} spec ${target.spec.fileName}.`;
+			options.output.appendLine(`[error] ${message}`);
+			return createGenerationResult('invalidTarget', target, artifactPath, rawOutput, startedAt, message);
+		}
+
+		if (isCancellationRequested(options.cancellationSignal)) {
+			const message = `Cancelled SVG generation for ${target.spec.name}`;
+			options.output.appendLine(`[cancelled] ${message}`);
+			return createGenerationResult('cancelled', target, artifactPath, rawOutput, startedAt, message);
+		}
+
+		const request = buildSpecGenerationRequest(target, options);
+		const runner = options.runner ?? nodeTestbenchProcessRunner;
+		writeGenerationExecutionDetails(options.output, target, request, artifactPath);
+
+		try {
+			const processResult = await runner.run(request, {
+				onStdout: (chunk) => {
+					rawOutput.stdout += chunk;
+					options.output.append(chunk);
+				},
+				onStderr: (chunk) => {
+					rawOutput.stderr += chunk;
+					options.output.append(chunk);
+				},
+			});
+
+			if (processResult.signal !== undefined || isCancellationRequested(options.cancellationSignal)) {
+				const message = `Cancelled SVG generation for ${target.spec.name}`;
+				options.output.appendLine('');
+				options.output.appendLine(`[cancelled] ${message}`);
+				return createGenerationResult(
+					'cancelled',
+					target,
+					artifactPath,
+					rawOutput,
+					startedAt,
+					message,
+					request,
+					processResult.exitCode,
+					processResult.signal,
+				);
+			}
+
+			if (processResult.exitCode !== 0) {
+				const message = `${request.args[0]} failed for ${target.spec.name} with exit code ${processResult.exitCode}`;
+				options.output.appendLine('');
+				options.output.appendLine(`[error] ${message}`);
+				return createGenerationResult(
+					'failed',
+					target,
+					artifactPath,
+					rawOutput,
+					startedAt,
+					message,
+					request,
+					processResult.exitCode,
+				);
+			}
+
+			if (!(await artifactExists(artifactPath, options))) {
+				const message = `Generated SVG was not found at ${artifactPath}.`;
+				options.output.appendLine('');
+				options.output.appendLine(`[error] ${message}`);
+				return createGenerationResult(
+					'missingArtifact',
+					target,
+					artifactPath,
+					rawOutput,
+					startedAt,
+					message,
+					request,
+					processResult.exitCode,
+				);
+			}
+
+			const message = `Generated ${target.spec.kind} SVG for ${target.spec.name}`;
+			options.output.appendLine('');
+			options.output.appendLine(`[ok] ${message}`);
+			options.output.appendLine(`[HDL Dev] Generated SVG: ${artifactPath}`);
+			return createGenerationResult(
+				'generated',
+				target,
+				artifactPath,
+				rawOutput,
+				startedAt,
+				message,
+				request,
+				processResult.exitCode,
+			);
+		} catch (error) {
+			if (isAbortError(error) || isCancellationRequested(options.cancellationSignal)) {
+				const message = `Cancelled SVG generation for ${target.spec.name}`;
+				options.output.appendLine('');
+				options.output.appendLine(`[cancelled] ${message}`);
+				return createGenerationResult(
+					'cancelled',
+					target,
+					artifactPath,
+					rawOutput,
+					startedAt,
+					message,
+					request,
+				);
+			}
+
+			const message = `Failed to generate SVG for ${target.spec.name}: ${errorMessage(error)}`;
+			options.output.appendLine('');
+			options.output.appendLine(`[error] ${message}`);
+			return createGenerationResult(
+				'errored',
+				target,
+				artifactPath,
+				rawOutput,
+				startedAt,
+				message,
+				request,
+			);
+		}
+	}
+}
+
+export function buildSpecGenerationRequest(
+	target: SpecGenerationTarget,
+	options: Pick<
+		SpecGenerationOptions,
+		| 'makeExecutable'
+		| 'env'
+		| 'environmentOverrides'
+		| 'cancellationSignal'
+	>,
+): TestbenchProcessRequest {
+	return {
+		executablePath: normalizeMakeExecutable(options.makeExecutable),
+		args: buildSpecGenerationArgs(target),
+		cwd: target.spec.projectRootPath,
+		env: buildTestbenchDiscoveryEnvironment(
+			options.env ?? process.env,
+			options.environmentOverrides ?? {},
+		),
+		signal: options.cancellationSignal,
+	};
+}
+
+export function getGeneratedSvgPath(spec: Pick<DiscoveredSpec, 'kind' | 'name' | 'projectRootPath'>): string {
+	const relativeDirectory = spec.kind === 'waveform'
+		? path.join('docs', 'waveforms', 'generated')
+		: path.join('docs', 'schematics', 'generated');
+
+	return path.join(spec.projectRootPath, relativeDirectory, `${spec.name}.svg`);
+}
+
+function buildSpecGenerationArgs(target: SpecGenerationTarget): string[] {
+	if (target.spec.kind === 'waveform') {
+		const args = [
+			'docs-waveforms',
+			`WAVEFORM=${target.spec.name}`,
+		];
+
+		if (target.mode === 'waveformNoRun') {
+			args.push('NO_RUN=1');
+		}
+
+		return args;
+	}
+
+	return [
+		'docs-schematics',
+		`SCHEMATIC=${target.spec.name}`,
+	];
+}
+
+function createGenerationResult(
+	outcome: SpecGenerationOutcome,
+	target: SpecGenerationTarget,
+	artifactPath: string,
+	rawOutput: SpecGenerationResult['rawOutput'],
+	startedAt: number,
+	message: string,
+	command?: TestbenchProcessRequest,
+	exitCode?: number,
+	signal?: NodeJS.Signals,
+): SpecGenerationResult {
+	return {
+		outcome,
+		execution: specGenerationExecution,
+		target,
+		command,
+		exitCode,
+		signal,
+		durationMs: Date.now() - startedAt,
+		artifactPath,
+		rawOutput,
+		message,
+	};
+}
+
+async function artifactExists(
+	artifactPath: string,
+	options: SpecGenerationOptions,
+): Promise<boolean> {
+	if (options.artifactExists !== undefined) {
+		return options.artifactExists(artifactPath);
+	}
+
+	try {
+		const stats = await fs.stat(artifactPath);
+		return stats.isFile();
+	} catch {
+		return false;
+	}
+}
+
+function isModeCompatibleWithSpec(target: SpecGenerationTarget): boolean {
+	if (target.spec.kind === 'waveform') {
+		return target.mode === 'waveform' || target.mode === 'waveformNoRun';
+	}
+
+	return target.mode === 'schematic';
+}
+
+function normalizeMakeExecutable(makeExecutable: string | undefined): string {
+	const trimmed = makeExecutable?.trim() ?? '';
+	return trimmed === '' ? defaultMakeExecutable : trimmed;
+}
+
+function writeGenerationHeader(
+	output: SpecGenerationOutput,
+	target: SpecGenerationTarget,
+): void {
+	output.appendLine('');
+	output.appendLine(`[HDL Dev] Generating ${target.spec.kind} SVG`);
+	output.appendLine('[HDL Dev] Profile: spec-svg-generation');
+	output.appendLine(`[HDL Dev] Spec: ${target.spec.name}`);
+	output.appendLine(`[HDL Dev] Spec file: ${target.spec.filePath}`);
+}
+
+function writeGenerationExecutionDetails(
+	output: SpecGenerationOutput,
+	target: SpecGenerationTarget,
+	request: TestbenchProcessRequest,
+	artifactPath: string,
+): void {
+	output.appendLine(`[HDL Dev] Mode: ${formatModeLabel(target.mode)}`);
+	output.appendLine(`[HDL Dev] Project root: ${target.spec.projectRootPath}`);
+	output.appendLine(`[HDL Dev] Executable: ${request.executablePath}`);
+	output.appendLine(`[HDL Dev] Arguments: ${JSON.stringify(request.args)}`);
+	output.appendLine(`[HDL Dev] Working directory: ${request.cwd}`);
+	output.appendLine(`[HDL Dev] Expected SVG: ${artifactPath}`);
+	output.appendLine('');
+}
+
+function formatModeLabel(mode: SpecGenerationMode): string {
+	if (mode === 'waveformNoRun') {
+		return 'waveform no-rerun';
+	}
+
+	return mode;
+}
+
+function isAbortError(error: unknown): boolean {
+	return error instanceof Error && error.name === 'AbortError';
+}
+
+function isCancellationRequested(signal: AbortSignal | undefined): boolean {
+	return signal?.aborted === true;
+}
+
+function errorMessage(error: unknown): string {
+	if (error instanceof Error) {
+		return error.message;
+	}
+
+	return String(error);
+}

--- a/src/specs/specGenerationCommands.ts
+++ b/src/specs/specGenerationCommands.ts
@@ -1,0 +1,112 @@
+import * as vscode from 'vscode';
+
+import {
+	SpecGenerationService,
+	type SpecGenerationMode,
+	type SpecGenerationOutput,
+	type SpecGenerationResult,
+} from './specGeneration';
+import type { DiscoveredSpec } from './specDiscovery';
+import type { SpecsTreeSpecNode } from './specsTree';
+
+export const generateWaveformSvgCommand = 'vscode-hdl-dev.generateWaveformSvg';
+export const generateWaveformSvgNoRunCommand = 'vscode-hdl-dev.generateWaveformSvgNoRun';
+export const generateSchematicSvgCommand = 'vscode-hdl-dev.generateSchematicSvg';
+
+export interface SpecGenerationCommandHost {
+	readonly workspaceTrusted: boolean;
+	readonly output: SpecGenerationOutput;
+	readonly service: SpecGenerationService;
+	readonly makeExecutable: string;
+	readonly environmentOverrides: NodeJS.ProcessEnv;
+	openGeneratedSvg(artifactPath: string): Thenable<unknown>;
+	showErrorMessage(message: string): Thenable<unknown>;
+	showInformationMessage(message: string): Thenable<unknown>;
+}
+
+export function registerSpecGenerationCommands(
+	context: vscode.ExtensionContext,
+	outputChannel: vscode.OutputChannel,
+): void {
+	const service = new SpecGenerationService();
+	const createHost = (): SpecGenerationCommandHost => {
+		const configuration = vscode.workspace.getConfiguration('hdlDev');
+		const toolchainRoot = configuration.get<string>('toolchainRoot', '').trim();
+
+		return {
+			workspaceTrusted: vscode.workspace.isTrusted,
+			output: outputChannel,
+			service,
+			makeExecutable: configuration.get<string>('makeExecutable', 'make'),
+			environmentOverrides: toolchainRoot === '' ? {} : { GHDL_TOOLCHAIN_ROOT: toolchainRoot },
+			openGeneratedSvg: (artifactPath) => vscode.commands.executeCommand('vscode.open', vscode.Uri.file(artifactPath)),
+			showErrorMessage: (message) => vscode.window.showErrorMessage(message),
+			showInformationMessage: (message) => vscode.window.showInformationMessage(message),
+		};
+	};
+
+	context.subscriptions.push(
+		vscode.commands.registerCommand(
+			generateWaveformSvgCommand,
+			(node?: SpecsTreeSpecNode) => runSpecGenerationCommand(createHost(), 'waveform', node),
+		),
+		vscode.commands.registerCommand(
+			generateWaveformSvgNoRunCommand,
+			(node?: SpecsTreeSpecNode) => runSpecGenerationCommand(createHost(), 'waveformNoRun', node),
+		),
+		vscode.commands.registerCommand(
+			generateSchematicSvgCommand,
+			(node?: SpecsTreeSpecNode) => runSpecGenerationCommand(createHost(), 'schematic', node),
+		),
+	);
+}
+
+export async function runSpecGenerationCommand(
+	host: SpecGenerationCommandHost,
+	mode: SpecGenerationMode,
+	node: SpecsTreeSpecNode | DiscoveredSpec | undefined,
+): Promise<SpecGenerationResult | undefined> {
+	const spec = resolveSpec(node);
+
+	if (spec === undefined) {
+		await host.showErrorMessage('Select a waveform or schematic spec from the Specs tree first.');
+		return undefined;
+	}
+
+	const result = await host.service.generateSpecSvg({
+		spec,
+		mode,
+	}, {
+		workspaceTrusted: host.workspaceTrusted,
+		makeExecutable: host.makeExecutable,
+		environmentOverrides: host.environmentOverrides,
+		output: host.output,
+	});
+
+	if (result.outcome === 'generated') {
+		await host.openGeneratedSvg(result.artifactPath);
+		await host.showInformationMessage(result.message);
+	} else if (result.outcome !== 'cancelled') {
+		await host.showErrorMessage(result.message);
+	}
+
+	return result;
+}
+
+function resolveSpec(
+	node: SpecsTreeSpecNode | DiscoveredSpec | undefined,
+): DiscoveredSpec | undefined {
+	if (node === undefined) {
+		return undefined;
+	}
+
+	if ('type' in node && node.type === 'spec') {
+		return node.spec;
+	}
+
+	if ('kind' in node && 'filePath' in node) {
+		return node;
+	}
+
+	return undefined;
+}

--- a/src/test/specGeneration.test.ts
+++ b/src/test/specGeneration.test.ts
@@ -1,0 +1,396 @@
+import * as assert from 'node:assert';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import {
+	generateSchematicSvgCommand,
+	generateWaveformSvgCommand,
+	generateWaveformSvgNoRunCommand,
+	runSpecGenerationCommand,
+	type SpecGenerationCommandHost,
+} from '../specs/specGenerationCommands';
+import {
+	buildSpecGenerationRequest,
+	getGeneratedSvgPath,
+	specGenerationExecution,
+	SpecGenerationService as CoreSpecGenerationService,
+	type SpecGenerationOutput,
+	type SpecGenerationOptions,
+	type SpecGenerationResult,
+	type SpecGenerationTarget,
+} from '../specs/specGeneration';
+import type { DiscoveredSpec } from '../specs/specDiscovery';
+import { specsTreeViewId } from '../specs/specsTree';
+import type {
+	TestbenchProcessEvents,
+	TestbenchProcessRequest,
+	TestbenchProcessResult,
+	TestbenchProcessRunner,
+} from '../testbench/testbenchDiscovery';
+
+const tempRoots: string[] = [];
+
+suite('Spec Generation', () => {
+	teardown(async () => {
+		await Promise.all(tempRoots.splice(0).map(async (tempRoot) => {
+			await fs.rm(tempRoot, { recursive: true, force: true });
+		}));
+	});
+
+	test('builds waveform, waveform no-rerun, and schematic Make requests', async () => {
+		const projectPath = await createTempProject();
+		const waveformSpec = createSpec(projectPath, 'waveform', 'timer-wave');
+		const schematicSpec = createSpec(projectPath, 'schematic', 'timer-core');
+
+		assert.deepStrictEqual(
+			buildSpecGenerationRequest({
+				spec: waveformSpec,
+				mode: 'waveform',
+			}, {
+				makeExecutable: 'gmake',
+				env: { PATH: '/usr/bin' },
+			}).args,
+			['docs-waveforms', 'WAVEFORM=timer-wave'],
+		);
+		assert.deepStrictEqual(
+			buildSpecGenerationRequest({
+				spec: waveformSpec,
+				mode: 'waveformNoRun',
+			}, {
+				makeExecutable: 'gmake',
+				env: { PATH: '/usr/bin' },
+			}).args,
+			['docs-waveforms', 'WAVEFORM=timer-wave', 'NO_RUN=1'],
+		);
+
+		const schematicRequest = buildSpecGenerationRequest({
+			spec: schematicSpec,
+			mode: 'schematic',
+		}, {
+			makeExecutable: 'gmake',
+			env: { PATH: '/usr/bin' },
+		});
+
+		assert.strictEqual(schematicRequest.executablePath, 'gmake');
+		assert.deepStrictEqual(schematicRequest.args, ['docs-schematics', 'SCHEMATIC=timer-core']);
+		assert.strictEqual(schematicRequest.cwd, projectPath);
+	});
+
+	test('preserves output and reports generated SVG artifacts', async () => {
+		const projectPath = await createTempProject();
+		const spec = createSpec(projectPath, 'waveform', 'timer-wave');
+		const output = new CapturingOutput();
+		const runner = new FakeProcessRunner({
+			exitCode: 0,
+			stdout: 'generating waveform svg\n',
+			stderr: 'python detail\n',
+		});
+
+		const result = await new CoreSpecGenerationService().generateSpecSvg({
+			spec,
+			mode: 'waveform',
+		}, {
+			workspaceTrusted: true,
+			output,
+			runner,
+			artifactExists: async () => true,
+		});
+
+		assert.strictEqual(result.outcome, 'generated');
+		assert.strictEqual(runner.requests.length, 1);
+		assert.strictEqual(result.rawOutput.stdout, 'generating waveform svg\n');
+		assert.strictEqual(result.rawOutput.stderr, 'python detail\n');
+		assert.match(output.text, /generating waveform svg/);
+		assert.match(output.text, /Generated SVG:/);
+		assert.strictEqual(result.artifactPath, getGeneratedSvgPath(spec));
+	});
+
+	test('reports missing SVG artifacts after a successful Make exit', async () => {
+		const projectPath = await createTempProject();
+		const spec = createSpec(projectPath, 'schematic', 'timer-core');
+		const result = await new CoreSpecGenerationService().generateSpecSvg({
+			spec,
+			mode: 'schematic',
+		}, {
+			workspaceTrusted: true,
+			output: new CapturingOutput(),
+			runner: new FakeProcessRunner({
+				exitCode: 0,
+			}),
+			artifactExists: async () => false,
+		});
+
+		assert.strictEqual(result.outcome, 'missingArtifact');
+		assert.match(result.message, /Generated SVG was not found/);
+		assert.match(result.message, /timer-core\.svg/);
+	});
+
+	test('blocks untrusted workspaces and invalid JSON specs before running Make', async () => {
+		const projectPath = await createTempProject();
+		const runner = new FakeProcessRunner({
+			exitCode: 0,
+		});
+		const blocked = await new CoreSpecGenerationService().generateSpecSvg({
+			spec: createSpec(projectPath, 'waveform', 'timer-wave'),
+			mode: 'waveform',
+		}, {
+			workspaceTrusted: false,
+			output: new CapturingOutput(),
+			runner,
+		});
+		const invalid = await new CoreSpecGenerationService().generateSpecSvg({
+			spec: createSpec(projectPath, 'waveform', 'broken-wave', 'invalid'),
+			mode: 'waveform',
+		}, {
+			workspaceTrusted: true,
+			output: new CapturingOutput(),
+			runner,
+		});
+
+		assert.strictEqual(blocked.outcome, 'blocked');
+		assert.strictEqual(invalid.outcome, 'invalidTarget');
+		assert.strictEqual(runner.requests.length, 0);
+	});
+
+	test('serializes generation that shares a project root', async () => {
+		const projectPath = await createTempProject();
+		const service = new CoreSpecGenerationService();
+		let activeRuns = 0;
+		let maxActiveRuns = 0;
+		const runner = new FakeProcessRunner(async () => {
+			activeRuns += 1;
+			maxActiveRuns = Math.max(maxActiveRuns, activeRuns);
+			await delay(20);
+			activeRuns -= 1;
+			return {
+				exitCode: 0,
+			};
+		});
+		const options = {
+			workspaceTrusted: true,
+			output: new CapturingOutput(),
+			runner,
+			artifactExists: async () => true,
+		};
+
+		await Promise.all([
+			service.generateSpecSvg({
+				spec: createSpec(projectPath, 'waveform', 'timer-wave'),
+				mode: 'waveform',
+			}, options),
+			service.generateSpecSvg({
+				spec: createSpec(projectPath, 'schematic', 'timer-core'),
+				mode: 'schematic',
+			}, options),
+		]);
+
+		assert.strictEqual(maxActiveRuns, 1);
+		assert.deepStrictEqual(
+			runner.requests.map((request) => request.args[0]),
+			['docs-waveforms', 'docs-schematics'],
+		);
+	});
+
+	test('opens generated SVGs after successful tree command execution', async () => {
+		const projectPath = await createTempProject();
+		const spec = createSpec(projectPath, 'waveform', 'timer-wave');
+		const generatedResult = createGeneratedResult(spec);
+		const service = new FakeSpecGenerationService(generatedResult);
+		const host = new CapturingCommandHost(service);
+
+		const result = await runSpecGenerationCommand(host, 'waveform', {
+			type: 'spec',
+			spec,
+		});
+
+		assert.strictEqual(result, generatedResult);
+		assert.deepStrictEqual(host.openedArtifacts, [generatedResult.artifactPath]);
+		assert.deepStrictEqual(host.informationMessages, [generatedResult.message]);
+		assert.deepStrictEqual(host.errorMessages, []);
+	});
+
+	test('package contributes Specs tree generation commands and context menus', async () => {
+		const packageJsonPath = path.join(__dirname, '..', '..', 'package.json');
+		const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf8')) as {
+			contributes: {
+				commands: Array<{ readonly command: string; readonly category?: string }>;
+				menus: {
+					'view/item/context': Array<{
+						readonly command: string;
+						readonly when: string;
+					}>;
+				};
+			};
+		};
+		const commandIds = packageJson.contributes.commands.map((command) => command.command);
+		const contextMenus = packageJson.contributes.menus['view/item/context'];
+
+		for (const command of [
+			generateWaveformSvgCommand,
+			generateWaveformSvgNoRunCommand,
+			generateSchematicSvgCommand,
+		]) {
+			assert.ok(commandIds.includes(command));
+		}
+
+		assert.ok(contextMenus.some((menu) => (
+			menu.command === generateWaveformSvgCommand
+				&& menu.when === `view == ${specsTreeViewId} && viewItem == hdlDev.specs.spec.waveform.valid`
+		)));
+		assert.ok(contextMenus.some((menu) => (
+			menu.command === generateWaveformSvgNoRunCommand
+				&& menu.when === `view == ${specsTreeViewId} && viewItem == hdlDev.specs.spec.waveform.valid`
+		)));
+		assert.ok(contextMenus.some((menu) => (
+			menu.command === generateSchematicSvgCommand
+				&& menu.when === `view == ${specsTreeViewId} && viewItem == hdlDev.specs.spec.schematic.valid`
+		)));
+	});
+});
+
+class CapturingOutput implements SpecGenerationOutput {
+	public text = '';
+	public shown = false;
+
+	append(value: string): void {
+		this.text += value;
+	}
+
+	appendLine(value: string): void {
+		this.text += `${value}\n`;
+	}
+
+	show(): void {
+		this.shown = true;
+	}
+}
+
+class CapturingCommandHost implements SpecGenerationCommandHost {
+	public readonly workspaceTrusted = true;
+	public readonly output = new CapturingOutput();
+	public readonly makeExecutable = 'make';
+	public readonly environmentOverrides = {};
+	public readonly openedArtifacts: string[] = [];
+	public readonly errorMessages: string[] = [];
+	public readonly informationMessages: string[] = [];
+
+	public constructor(public readonly service: CoreSpecGenerationService) {}
+
+	public async openGeneratedSvg(artifactPath: string): Promise<void> {
+		this.openedArtifacts.push(artifactPath);
+	}
+
+	public async showErrorMessage(message: string): Promise<void> {
+		this.errorMessages.push(message);
+	}
+
+	public async showInformationMessage(message: string): Promise<void> {
+		this.informationMessages.push(message);
+	}
+}
+
+class FakeSpecGenerationService extends CoreSpecGenerationService {
+	public constructor(private readonly result: SpecGenerationResult) {
+		super();
+	}
+
+	public override async generateSpecSvg(
+		_target: SpecGenerationTarget,
+		_options: SpecGenerationOptions,
+	): Promise<SpecGenerationResult> {
+		return this.result;
+	}
+}
+
+type FakeProcessResponse = TestbenchProcessResult & {
+	readonly stdout?: string;
+	readonly stderr?: string;
+	readonly delayMs?: number;
+};
+
+type FakeProcessHandler = (request: TestbenchProcessRequest) => FakeProcessResponse | Promise<FakeProcessResponse>;
+
+class FakeProcessRunner implements TestbenchProcessRunner {
+	public readonly requests: TestbenchProcessRequest[] = [];
+	private readonly handler: FakeProcessHandler;
+
+	public constructor(response: FakeProcessResponse | FakeProcessHandler) {
+		this.handler = typeof response === 'function' ? response : () => response;
+	}
+
+	public async run(
+		request: TestbenchProcessRequest,
+		events: TestbenchProcessEvents,
+	): Promise<TestbenchProcessResult> {
+		this.requests.push(request);
+		const response = await this.handler(request);
+
+		if (response.delayMs !== undefined) {
+			await delay(response.delayMs);
+		}
+
+		if (response.stdout !== undefined) {
+			events.onStdout(response.stdout);
+		}
+
+		if (response.stderr !== undefined) {
+			events.onStderr(response.stderr);
+		}
+
+		return response;
+	}
+}
+
+async function createTempProject(): Promise<string> {
+	const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'hdl-dev-spec-generation-'));
+	tempRoots.push(tempRoot);
+	return tempRoot;
+}
+
+function createSpec(
+	projectRootPath: string,
+	kind: DiscoveredSpec['kind'],
+	name: string,
+	status: DiscoveredSpec['status'] = 'valid',
+): DiscoveredSpec {
+	const specDirectory = kind === 'waveform'
+		? path.join('docs', 'waveforms', 'specs')
+		: path.join('docs', 'schematics', 'specs');
+	const fileName = `${name}.json`;
+	const filePath = path.join(projectRootPath, specDirectory, fileName);
+
+	return {
+		id: `${projectRootPath}::${kind}::${name}`,
+		kind,
+		status,
+		name,
+		fileName,
+		filePath,
+		projectRootPath,
+		relativePath: path.relative(projectRootPath, filePath),
+		errorMessage: status === 'invalid' ? 'Invalid JSON: Unexpected token' : undefined,
+	};
+}
+
+function createGeneratedResult(spec: DiscoveredSpec): SpecGenerationResult {
+	return {
+		outcome: 'generated',
+		execution: specGenerationExecution,
+		target: {
+			spec,
+			mode: 'waveform',
+		},
+		durationMs: 1,
+		artifactPath: getGeneratedSvgPath(spec),
+		rawOutput: {
+			stdout: 'generated\n',
+			stderr: '',
+		},
+		message: `Generated waveform SVG for ${spec.name}`,
+	};
+}
+
+async function delay(ms: number): Promise<void> {
+	await new Promise((resolve) => setTimeout(resolve, ms));
+}


### PR DESCRIPTION
## Summary

Refs #8.

- Add Make-backed waveform and schematic SVG generation services for Specs tree items, including `NO_RUN=1` waveform generation.
- Add Specs tree context menu commands that run generation, preserve raw output in HDL Dev, verify the expected SVG, and open the generated artifact.
- Document the v0.3 generation contract and add automated coverage for command construction, output handling, missing artifacts, trust blocking, serialization, context menus, and open behavior.

## Validation

- `npm run compile`
- `npm run lint`
- `make docs-build`
- `git diff --check`
- `XDG_RUNTIME_DIR=$(mktemp -d /tmp/hdl-dev-vscode-runtime-XXXXXX) npm test` - 40 passing

## Manual Fixture Evidence

```text
[HDL Dev] Generating waveform SVG
[HDL Dev] Profile: spec-svg-generation
[HDL Dev] Spec: timer-wave
[HDL Dev] Mode: waveform no-rerun
[HDL Dev] Arguments: ["docs-waveforms","WAVEFORM=timer-wave","NO_RUN=1"]
waveform svg timer-wave no_run=1
[ok] Generated waveform SVG for timer-wave
[HDL Dev] Generated SVG: docs/waveforms/generated/timer-wave.svg

[HDL Dev] Generating schematic SVG
[HDL Dev] Profile: spec-svg-generation
[HDL Dev] Spec: timer-core
[HDL Dev] Mode: schematic
[HDL Dev] Arguments: ["docs-schematics","SCHEMATIC=timer-core"]
schematic svg timer-core
[ok] Generated schematic SVG for timer-core
[HDL Dev] Generated SVG: docs/schematics/generated/timer-core.svg

[manual] waveform outcome=generated artifact=docs/waveforms/generated/timer-wave.svg
[manual] schematic outcome=generated artifact=docs/schematics/generated/timer-core.svg
[artifact] <svg xmlns="http://www.w3.org/2000/svg"><text>timer-wave</text></svg>
[artifact] <svg xmlns="http://www.w3.org/2000/svg"><text>timer-core</text></svg>
```

## Context Action Capture

```text
Specs tree context menus
  hdlDev.specs.spec.waveform.valid
    HDL Dev: Generate Waveform SVG
    HDL Dev: Generate Waveform SVG Without Rerun
  hdlDev.specs.spec.schematic.valid
    HDL Dev: Generate Schematic SVG
```

## Remote Checks

- Git Flow Policy: https://github.com/cosgroma/vscode-hdl-dev/actions/runs/24637129568
- CI: https://github.com/cosgroma/vscode-hdl-dev/actions/runs/24637129592
- Pages: https://github.com/cosgroma/vscode-hdl-dev/actions/runs/24637129566
- Doctor GHDL Smoke: https://github.com/cosgroma/vscode-hdl-dev/actions/runs/24637129588