### PR TITLE
Document Specs tree milestone evidence (#9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ Design notes live under `docs/` and are published through MkDocs:
 - [v0.2 Native Testbench Runner](docs/workflows/v0.2-testbench-discovery.md)
 - [v0.2 Native Testbench Runner Evidence](docs/workflows/v0.2-native-testbench-runner-evidence.md)
 - [v0.3 Specs Tree](docs/workflows/v0.3-specs-tree.md)
+- [v0.3 Specs Tree Evidence](docs/workflows/v0.3-specs-tree-evidence.md)
 - [Project Discovery](docs/design/project-discovery.md)
 - [Initial Extension Design](docs/design/initial-extension-design.md)
 - [MVP Roadmap](docs/design/mvp-roadmap.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,9 @@ repo's own extension-facing command-line workflow.
 - [v0.3 Specs Tree](workflows/v0.3-specs-tree.md) describes the HDL view
   container, Specs tree grouping, refresh behavior, context values, and
   invalid-JSON handling.
+- [v0.3 Specs Tree Evidence](workflows/v0.3-specs-tree-evidence.md) records the
+  milestone evidence scope, automated coverage, generated SVG fixture evidence,
+  and context action capture for closing v0.3.
 - [Initial Extension Design](design/initial-extension-design.md) describes the
   proposed feature areas, VS Code surfaces, and implementation boundaries.
 - [Project Discovery](design/project-discovery.md) documents the passive

--- a/docs/workflows/v0.3-specs-tree-evidence.md
+++ b/docs/workflows/v0.3-specs-tree-evidence.md
@@ -1,0 +1,149 @@
+# v0.3 Specs Tree Evidence
+
+This page records the evidence scope for closing the v0.3 Specs Tree milestone.
+The extension keeps HDL project Makefiles and spec files as the source of truth,
+then exposes discovery and SVG generation through native VS Code tree and
+command surfaces.
+
+## Shipped Scope
+
+v0.3 is split across three GitHub issues:
+
+- `#7`: add the `HDL` Activity Bar view container and `Specs` tree
+- `#8`: generate waveform and schematic SVGs from selected specs
+- `#9`: collect and review milestone evidence
+
+Issues `#7` and `#8` are complete before this evidence gate closes.
+
+## User Workflow
+
+The Activity Bar contains an `HDL` view container. Its `Specs` tree appears
+when passive discovery finds at least one HDL project with a `Makefile` and a
+waveform or schematic spec directory.
+
+The tree groups specs by project and type:
+
+```text
+HDL
+  Specs
+    timer
+      Waveform Specs
+        timer-wave.json
+      Schematic Specs
+        broken.json  Invalid JSON
+        timer-core.json
+```
+
+Valid spec JSON opens in the normal editor when selected. Malformed JSON does
+not block the tree; the affected item is shown with an invalid context value,
+warning icon, and parse-error tooltip.
+
+## Commands
+
+The Specs tree contributes these commands:
+
+```text
+HDL Dev: Refresh Specs
+HDL Dev: Generate Waveform SVG
+HDL Dev: Generate Waveform SVG Without Rerun
+HDL Dev: Generate Schematic SVG
+```
+
+Generation commands run from the selected spec's project root and use explicit
+Make arguments:
+
+```text
+make docs-waveforms WAVEFORM=<spec-name>
+make docs-waveforms WAVEFORM=<spec-name> NO_RUN=1
+make docs-schematics SCHEMATIC=<spec-name>
+```
+
+After a successful Make exit, HDL Dev verifies and opens the generated SVG:
+
+```text
+docs/waveforms/generated/<spec-name>.svg
+docs/schematics/generated/<spec-name>.svg
+```
+
+Missing SVG output after a successful Make exit is reported as an actionable
+error with the expected artifact path.
+
+## Trust And Serialization
+
+Spec discovery is passive file reading and does not require workspace trust.
+
+SVG generation runs project Make targets, so generation commands are blocked
+until the workspace is trusted. Generation is serialized per project root so
+waveform and schematic generation commands do not race in a shared build
+directory.
+
+## Automated Coverage
+
+The extension test suite covers the v0.3 behavior in these suites:
+
+- `Spec Discovery`: waveform and schematic spec discovery, stable IDs, empty
+  spec directories, and malformed JSON that does not block valid specs
+- `Specs Tree`: tree item creation, empty states, HDL project context, view
+  container contribution, Specs view contribution, and refresh command
+- `Spec Generation`: waveform, no-rerun waveform, and schematic Make argument
+  construction; raw output preservation; missing artifact handling; workspace
+  trust blocking; malformed JSON blocking; per-project serialization; generated
+  SVG open behavior; and Specs tree context menu contributions
+- `Project Discovery`: passive project detection and spec directory capability
+  modeling
+
+The milestone evidence command set is:
+
+```bash
+npm run compile
+npm run lint
+git diff --check
+make docs-build
+XDG_RUNTIME_DIR=$(mktemp -d /tmp/hdl-dev-vscode-runtime-XXXXXX) npm test
+```
+
+## Manual Evidence
+
+The evidence gate uses a temporary Makefile fixture that creates one waveform
+SVG and one schematic SVG. The expected transcript shape is:
+
+```text
+[HDL Dev] Generating waveform SVG
+[HDL Dev] Profile: spec-svg-generation
+[HDL Dev] Spec: timer-wave
+[HDL Dev] Mode: waveform no-rerun
+[HDL Dev] Arguments: ["docs-waveforms","WAVEFORM=timer-wave","NO_RUN=1"]
+
+waveform svg timer-wave no_run=1
+
+[ok] Generated waveform SVG for timer-wave
+[HDL Dev] Generated SVG: docs/waveforms/generated/timer-wave.svg
+
+[HDL Dev] Generating schematic SVG
+[HDL Dev] Profile: spec-svg-generation
+[HDL Dev] Spec: timer-core
+[HDL Dev] Mode: schematic
+[HDL Dev] Arguments: ["docs-schematics","SCHEMATIC=timer-core"]
+
+schematic svg timer-core
+
+[ok] Generated schematic SVG for timer-core
+[HDL Dev] Generated SVG: docs/schematics/generated/timer-core.svg
+```
+
+The same evidence records the generated SVG contents:
+
+```text
+[artifact] <svg xmlns="http://www.w3.org/2000/svg"><text>timer-wave</text></svg>
+[artifact] <svg xmlns="http://www.w3.org/2000/svg"><text>timer-core</text></svg>
+```
+
+The context action capture is:
+
+```text
+hdlDev.specs.spec.waveform.valid -> Generate Waveform SVG, Generate Waveform SVG Without Rerun
+hdlDev.specs.spec.schematic.valid -> Generate Schematic SVG
+```
+
+The GitHub issue evidence comment carries the exact local transcript and remote
+workflow URLs used for final review.

--- a/docs/workflows/v0.3-specs-tree.md
+++ b/docs/workflows/v0.3-specs-tree.md
@@ -141,3 +141,10 @@ and schematic commands do not race in a shared build directory.
 - Schema-level waveform and schematic validation is not implemented yet.
 - Generated SVG and intermediate artifact navigation are deferred to later
   Specs and Artifact Explorer work.
+
+## Evidence
+
+The v0.3 milestone evidence page records the proof used to close the Specs tree
+milestone:
+
+- [v0.3 Specs Tree Evidence](v0.3-specs-tree-evidence.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,6 +20,7 @@ nav:
       - v0.2 Native Testbench Runner: workflows/v0.2-testbench-discovery.md
       - v0.2 Native Testbench Runner Evidence: workflows/v0.2-native-testbench-runner-evidence.md
       - v0.3 Specs Tree: workflows/v0.3-specs-tree.md
+      - v0.3 Specs Tree Evidence: workflows/v0.3-specs-tree-evidence.md
   - Design:
       - Project Discovery: design/project-discovery.md
       - Initial Extension Design: design/initial-extension-design.md


### PR DESCRIPTION
## Summary

Refs #9.

- Add a v0.3 Specs Tree evidence page that ties together shipped scope from #7 and #8.
- Record the user workflow, generation commands, trust behavior, automated coverage, manual SVG fixture evidence, and context action capture.
- Link the evidence page from the v0.3 workflow page, docs index, MkDocs navigation, and root README.

## Validation

- `npm run compile`
- `npm run lint`
- `make docs-build`
- `git diff --check`
- `XDG_RUNTIME_DIR=$(mktemp -d /tmp/hdl-dev-vscode-runtime-XXXXXX) npm test` - 40 passing

## Manual Evidence Recorded

```text
HDL
  Specs
    timer
      Waveform Specs
        timer-wave.json
      Schematic Specs
        broken.json  Invalid JSON
        timer-core.json

[HDL Dev] Arguments: ["docs-waveforms","WAVEFORM=timer-wave","NO_RUN=1"]
[ok] Generated waveform SVG for timer-wave
[HDL Dev] Generated SVG: docs/waveforms/generated/timer-wave.svg

[HDL Dev] Arguments: ["docs-schematics","SCHEMATIC=timer-core"]
[ok] Generated schematic SVG for timer-core
[HDL Dev] Generated SVG: docs/schematics/generated/timer-core.svg

hdlDev.specs.spec.waveform.valid -> Generate Waveform SVG, Generate Waveform SVG Without Rerun
hdlDev.specs.spec.schematic.valid -> Generate Schematic SVG
```

## Prior v0.3 Implementation Proof

- #7 PR: https://github.com/cosgroma/vscode-hdl-dev/pull/25
- #8 PR: https://github.com/cosgroma/vscode-hdl-dev/pull/26

## Remote Checks

- Git Flow Policy: https://github.com/cosgroma/vscode-hdl-dev/actions/runs/24637371698
- CI: https://github.com/cosgroma/vscode-hdl-dev/actions/runs/24637371705
- Pages: https://github.com/cosgroma/vscode-hdl-dev/actions/runs/24637371694