### PR TITLE
Initialize agent harness structure (#30)

### DIFF
--- a/.agents/skills/hdl-dev-issue-work/SKILL.md
+++ b/.agents/skills/hdl-dev-issue-work/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: hdl-dev-issue-work
+description: Use when implementing, reviewing, or finishing issue-scoped work in the vscode-hdl-dev repository; follows the repo's GitHub Project queue, git-flow branch model, validation matrix, and evidence requirements.
+---
+
+# HDL Dev Issue Work
+
+Use this skill for issue-scoped work in `cosgroma/vscode-hdl-dev`.
+
+1. Read `AGENTS.md`, `docs/agent/issue-workflow.md`, `docs/agent/validation.md`,
+   and `ARCHITECTURE.md`.
+2. Identify the issue. If the user did not name one, use the Ready Queue rules
+   in `docs/agent/issue-workflow.md`.
+3. Start from `develop` and create the matching git-flow branch.
+4. Read the workflow, design, and evidence docs for the touched surface.
+5. Keep implementation changes narrow and issue-scoped.
+6. Run the validation commands from `docs/agent/validation.md`.
+7. Commit a coherent chunk that references the issue number.
+8. In the handoff, include issue, files changed, checks, commit SHA, evidence,
+   and the recommended next chunk.
+
+Do not duplicate the full workflow here. Update the repo docs when the durable
+process changes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,9 +1,20 @@
 # Agent Instructions
 
 This repository uses issue-driven git-flow. Keep changes small, traceable, and
-evidence-backed.
+evidence-backed. Treat this file as a map; durable workflow, architecture, and
+validation details live in the linked repo docs.
 
-## Project Context
+## Start Here
+
+- Agent harness map: `docs/agent/README.md`
+- Issue workflow and git-flow details: `docs/agent/issue-workflow.md`
+- Validation matrix: `docs/agent/validation.md`
+- Architecture map and module boundaries: `ARCHITECTURE.md`
+- Roadmap: `docs/design/mvp-roadmap.md`
+- Design direction: `docs/design/initial-extension-design.md`
+- Public docs index: `docs/README.md`
+- Project board: `HDL Dev Roadmap`
+  <https://github.com/users/cosgroma/projects/3>
 
 HDL Dev is a VS Code extension for coordinating HDL project workflows from
 inside the editor. The design direction is to keep repo-local HDL scripts as the
@@ -11,184 +22,36 @@ source of truth and wrap them with native VS Code surfaces: commands, Output
 channels, the Testing API, tree views, status items, and focused artifact
 previews.
 
-Primary planning sources:
+## Operating Rules
 
-- GitHub Project: `HDL Dev Roadmap`
-  <https://github.com/users/cosgroma/projects/3>
-- Repository: `cosgroma/vscode-hdl-dev`
-- Roadmap: `docs/design/mvp-roadmap.md`
-- Design: `docs/design/initial-extension-design.md`
-- Public docs: <https://cosgroma.github.io/vscode-hdl-dev/>
+- Start from an existing GitHub issue when possible. If the user asks for
+  untracked work, create or identify a tracking issue before branching unless
+  they explicitly tell you not to.
+- Use the `Ready Queue` project view when choosing work without a direct user
+  request: `Readiness = Ready`, sorted by `Recommended Order`.
+- Start normal work from `develop` with
+  `git flow feature start <issue-number>-short-slug`.
+- Use `bugfix`, `release`, `hotfix`, or `support` only when the issue matches
+  that branch type.
+- Do not commit feature work directly to `main`.
+- Commit coherent chunks that compile or are clearly isolated docs/planning
+  changes. Reference the issue number in every commit message.
+- Use closing keywords only in the final commit or PR that fully satisfies the
+  issue.
 
-## Finding Work
+## Implementation Invariants
 
-Start by finding the next ready issue rather than inventing work.
-
-Preferred GitHub UI view:
-
-- Open the `HDL Dev Roadmap` project.
-- Use the `Ready Queue` view described in the project README:
-  `Readiness = Ready`, sorted by `Recommended Order`.
-- Pick the lowest-order issue that is not already in progress.
-
-Useful CLI checks:
-
-```bash
-gh issue list \
-  --repo cosgroma/vscode-hdl-dev \
-  --state open \
-  --limit 100 \
-  --json number,title,milestone,labels,url
-
-gh project item-list 3 \
-  --owner cosgroma \
-  --limit 100 \
-  --format json
-```
-
-To inspect project planning fields from the CLI:
-
-```bash
-gh api graphql \
-  -f login=cosgroma \
-  -F number=3 \
-  -f query='
-query($login: String!, $number: Int!) {
-  user(login: $login) {
-    projectV2(number: $number) {
-      items(first: 50) {
-        nodes {
-          content { ... on Issue { number title url } }
-          fieldValues(first: 20) {
-            nodes {
-              ... on ProjectV2ItemFieldNumberValue {
-                number
-                field { ... on ProjectV2FieldCommon { name } }
-              }
-              ... on ProjectV2ItemFieldTextValue {
-                text
-                field { ... on ProjectV2FieldCommon { name } }
-              }
-              ... on ProjectV2ItemFieldSingleSelectValue {
-                name
-                field { ... on ProjectV2FieldCommon { name } }
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-}'
-```
-
-Treat `Readiness = Ready` and the lowest `Recommended Order` as the default next
-work queue. If you choose a different issue, explain why in the PR or handoff.
-
-## Git Flow
-
-The branch model is:
-
-- `main`: production branch and GitHub Pages deployment source
-- `develop`: default branch and integration branch
-- `feature/*`: normal feature work from `develop`
-- `bugfix/*`: non-release bug fixes from `develop`
-- `release/*`: release stabilization from `develop`, merged to `main` and
-  `develop`
-- `hotfix/*`: urgent production fixes from `main`, merged to `main` and
-  `develop`
-- `support/*`: long-lived maintenance branches when needed
-
-Before starting work:
-
-```bash
-git fetch origin
-git checkout develop
-git pull --ff-only origin develop
-git status --short --branch
-```
-
-Start issue work with a git-flow branch:
-
-```bash
-git flow feature start <issue-number>-short-slug
-```
-
-Examples:
-
-```bash
-git flow feature start 1-project-discovery
-git flow feature start 2-dependency-doctor
-```
-
-Use `bugfix`, `release`, or `hotfix` only when the issue and branch direction
-match that kind of work.
-
-Finish normal feature work back to `develop`:
-
-```bash
-git flow feature finish <issue-number>-short-slug
-git push origin develop
-```
-
-Do not commit feature work directly to `main`. `main` only accepts `release/*`
-and `hotfix/*` pull requests.
-
-## Commit Methodology
-
-Commit whenever a coherent chunk of work lands. A coherent chunk should compile
-or be clearly isolated documentation/planning work.
-
-Every commit that implements or documents issue-scoped work must reference the
-issue number in the commit message.
-
-Preferred commit message style:
-
-```text
-Add project discovery service (#1)
-Test dependency doctor trust handling (#2)
-Document v0.1 evidence checklist (#3)
-```
-
-Use closing keywords only in the final commit or PR that fully satisfies the
-issue:
-
-```text
-Complete Dependency Doctor workflow (fixes #2)
-```
-
-Do not use `fixes #N` for partial work. Use plain references like `refs #N`,
-`for #N`, or `(#N)` until the acceptance criteria and evidence checklist are
-complete.
-
-When a chunk lands:
-
-1. Run the relevant checks.
-2. Commit with the issue number in the message.
-3. Push the branch or `develop` when appropriate.
-4. Capture evidence in the issue or PR.
-5. Recommend the next chunk of work in your final response or handoff.
-
-## Evidence Requirements
-
-Issues are not done until their `Evidence Required` checklist is satisfied.
-Typical evidence includes:
-
-- CI run URL
-- Doctor smoke URL or local `make deps-check-ghdl` transcript
-- `make docs-build` output or Pages run URL
-- screenshots or short captures for visible VS Code surfaces
-- test output for the relevant service, command, or UI behavior
-- documentation updates where the issue changes user-facing behavior
-
-Use the GitHub Project `Evidence State` field:
-
-- `Needs Evidence`: implementation or proof is incomplete
-- `Evidence Ready`: evidence has been collected and is ready for review
-- `Accepted`: maintainer accepts the evidence and the issue can close
-
-Milestone evidence gate issues must not close until all implementation issues in
-that milestone are closed or explicitly moved.
+- Prefer repo patterns over new abstractions.
+- Keep HDL project scripts and Make targets as the source of truth.
+- Use explicit process argument arrays in TypeScript where possible.
+- Respect workspace trust before running scripts, Make, GHDL, Python, Yosys, or
+  `netlistsvg`.
+- Serialize commands that share a project build directory.
+- Preserve raw command output in the HDL Dev Output channel or test output.
+- Add machine-readable script output only when the extension needs reliable
+  introspection.
+- Promote repeated review feedback into docs, tests, scripts, or lintable rules
+  instead of growing this file.
 
 ## Validation
 
@@ -200,40 +63,14 @@ npm run compile
 npm test
 make docs-build
 make deps-check-ghdl
+make agent-harness-check
 ```
 
-For workflow changes, parse workflow YAML:
+Use `docs/agent/validation.md` for the full validation matrix, including
+workflow YAML checks, Doctor smoke checks, docs checks, and evidence capture
+expectations.
 
-```bash
-python3 - <<'PY'
-import pathlib, yaml
-for path in pathlib.Path(".github/workflows").glob("*.yml"):
-    with path.open() as f:
-        yaml.safe_load(f)
-    print(f"ok {path}")
-PY
-```
-
-For dependency or Doctor changes, run:
-
-```bash
-make deps-install-ghdl
-make deps-check-ghdl
-```
-
-## Implementation Principles
-
-- Prefer repo patterns over new abstractions.
-- Keep HDL project scripts and Make targets as the source of truth.
-- Use explicit process argument arrays in TypeScript where possible.
-- Respect workspace trust before running scripts, Make, GHDL, Python, Yosys, or
-  `netlistsvg`.
-- Serialize commands that share a project build directory.
-- Preserve raw command output in the HDL Dev Output channel or test output.
-- Add machine-readable script output only when the extension needs reliable
-  introspection.
-
-## Handoff Expectations
+## Handoff
 
 At the end of a work session, report:
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,87 @@
+# Architecture
+
+HDL Dev is a VS Code-native coordinator around HDL project scripts. The
+extension should make existing Makefile and script workflows discoverable,
+trust-aware, and inspectable without replacing the HDL project's own source of
+truth.
+
+## Source Map
+
+| Path | Responsibility |
+| --- | --- |
+| `src/extension.ts` | Extension activation, shared Output channel, status item, and command registration. |
+| `src/discovery/` | Passive HDL project discovery. This layer reads files only and does not require workspace trust. |
+| `src/doctor/` | Dependency Doctor command orchestration around repo-local dependency scripts. This layer is trust-sensitive because it executes workspace code. |
+| `src/testbench/` | VS Code Testing API integration, Make-backed testbench discovery, and serialized testbench execution. |
+| `src/specs/` | Waveform and schematic spec discovery, Specs tree presentation, and Make-backed SVG generation commands. |
+| `src/artifacts/` | Passive generated artifact discovery, Artifacts tree presentation, and open/reveal/copy commands. |
+| `src/test/` | Extension and service tests. Tests should prefer core services with injected hosts before full VS Code integration when possible. |
+| `scripts/` | Repository-owned dependency and validation entry points. These scripts are the automation surface for agents and CI. |
+| `docs/` | Versioned design, workflow, evidence, and agent-harness knowledge. |
+| `test-fixtures/` | Reusable local projects and files for tests, reproduction, and manual evidence. |
+
+## Boundary Rules
+
+- Passive discovery is allowed before workspace trust. It may inspect files and
+  directories, but it must not run Make, shell scripts, Python, GHDL, Yosys, or
+  `netlistsvg`.
+- Execution paths must check workspace trust before running workspace-owned
+  scripts or tools.
+- Process requests should keep the executable and arguments separate. Make
+  variable assignments such as `TB=timer_tb` and `STOP_TIME=500us` should be
+  individual arguments.
+- Commands that share a project build directory must serialize per project root.
+- Raw command output belongs in the HDL Dev Output channel or test output. Do
+  not replace raw logs with summarized status only.
+- Tree views are passive indexes and command launch points. They should not
+  mutate files during refresh.
+- Webviews are reserved for inspection workflows that native editors or tree
+  views cannot handle well.
+
+## Extension Shape
+
+The extension favors small service modules with testable core behavior and thin
+VS Code registration layers:
+
+1. Build a pure request or discovery model.
+2. Inject filesystem, process, output, or VS Code host dependencies at the edge.
+3. Preserve raw output and structured result state.
+4. Register VS Code commands, views, and Testing API objects around that core.
+
+This keeps most behavior verifiable in `src/test/` without launching a full
+workspace for every case, while still allowing focused VS Code integration tests
+where the extension contribution surface matters.
+
+## Script Contracts
+
+HDL Dev should keep local HDL project scripts and Make targets authoritative.
+Current extension-facing contracts include:
+
+```text
+scripts/deps.sh check ghdl
+scripts/deps.sh check docs-assets
+make list-tbs
+make test TB=<name> STOP_TIME=<time> WAVE_FORMAT=<format>
+make docs-waveforms WAVEFORM=<name>
+make docs-waveforms WAVEFORM=<name> NO_RUN=1
+make docs-schematics SCHEMATIC=<name>
+```
+
+Future machine-readable outputs should be additive. Prefer adding JSON modes to
+the scripts when the extension needs reliable introspection instead of scraping
+human-oriented output.
+
+## Documentation Contract
+
+`AGENTS.md` is the compact entry point. Durable details live in versioned docs:
+
+- `docs/agent/` for agent workflow and validation.
+- `docs/design/` for design decisions and roadmap.
+- `docs/workflows/` for shipped workflow contracts and milestone evidence.
+- `docs/plans/` for execution plans that need progress logs.
+- `docs/quality/` for golden principles and debt tracking.
+- `docs/references/` for external API and UX references.
+
+When a human preference or review comment should affect future agent work, add
+it to one of those sources or encode it in a script/test. Avoid turning
+`AGENTS.md` into a long manual.

--- a/Makefile
+++ b/Makefile
@@ -105,3 +105,8 @@ docs-install: ##@ Install MkDocs dependencies.
 .PHONY: docs-build
 docs-build: ##@ Build the MkDocs site.
 	"$(MKDOCS)" build --strict --site-dir "$(DOCS_SITE_DIR)"
+
+##@ Agent Harness
+.PHONY: agent-harness-check
+agent-harness-check: ##@ Validate agent harness docs, links, fixtures, and nav.
+	node scripts/validate-agent-harness.mjs

--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ npm run compile
 npm test
 make docs-build
 make deps-check-ghdl
+make agent-harness-check
 ```
 
 The Doctor smoke workflow uses the repo-owned dependency scripts rather than
@@ -188,6 +189,9 @@ Initial scaffold and project infrastructure:
 
 Design notes live under `docs/` and are published through MkDocs:
 
+- [Agent Harness](docs/agent/README.md)
+- [Architecture](ARCHITECTURE.md)
+- [Validation](docs/agent/validation.md)
 - [VS Code Workbench References](docs/references/vscode-workbench-surfaces.md)
 - [GEnCor Integration Notes](docs/integrations/gencor.md)
 - [v0.1 Project Discovery And Dependency Doctor](docs/workflows/v0.1-project-discovery-and-doctor.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,47 +1,25 @@
 # HDL Dev Extension Docs
 
-This directory captures the early design notes for the HDL Dev VS Code extension.
-The intent is to keep the extension aligned with VS Code's native UI surfaces
-while adapting the dependency and Makefile patterns proven in GEnCor into this
-repo's own extension-facing command-line workflow.
+This directory is the repository knowledge base for HDL Dev. It keeps design
+direction, workflow contracts, validation rules, evidence, and agent harness
+materials versioned with the code.
 
-## Documents
+## Document Areas
 
-- [VS Code Workbench References](references/vscode-workbench-surfaces.md) records
-  the official VS Code docs we are using for UI and command-surface decisions.
+- [Agent Harness](agent/README.md) maps the repo-local workflow, validation, and
+  issue-driven development structure for Codex and other coding agents.
+- [Design](design/index.md) indexes design direction, roadmap, and repository
+  infrastructure decisions.
+- [Workflows](workflows/index.md) indexes shipped workflow contracts and
+  milestone evidence notes.
+- [References](references/index.md) indexes external API, UX, and integration
+  references.
+- [Plans](plans/README.md) explains active and completed execution plans.
+- [Quality](quality/golden-principles.md) captures durable principles, while
+  [Technical Debt Tracker](quality/tech-debt-tracker.md) tracks known debt.
+- [Evidence](evidence/README.md) explains versioned evidence artifacts.
 - [GEnCor Integration Notes](integrations/gencor.md) summarizes the GEnCor flows
-  we plan to adapt: dependency checks, GHDL testbench runs, waveform SVG
-  generation, schematic SVG generation, and packetized-I/O debug helpers.
-- [v0.1 Project Discovery And Dependency Doctor](workflows/v0.1-project-discovery-and-doctor.md)
-  describes the shipped discovery and dependency-check workflow, expected
-  output, trust behavior, and evidence coverage.
-- [v0.2 Native Testbench Runner](workflows/v0.2-testbench-discovery.md)
-  describes the `make list-tbs` discovery contract, `make test` run contract,
-  Testing API surface, trust behavior, and managed Makefile pattern.
-- [v0.2 Native Testbench Runner Evidence](workflows/v0.2-native-testbench-runner-evidence.md)
-  records the milestone evidence scope, test coverage, artifact expectations,
-  and manual transcript shape for closing v0.2.
-- [v0.3 Specs Tree](workflows/v0.3-specs-tree.md) describes the HDL view
-  container, Specs tree grouping, refresh behavior, context values, and
-  invalid-JSON handling.
-- [v0.3 Specs Tree Evidence](workflows/v0.3-specs-tree-evidence.md) records the
-  milestone evidence scope, automated coverage, generated SVG fixture evidence,
-  and context action capture for closing v0.3.
-- [v0.4 Artifact Explorer](workflows/v0.4-artifact-explorer.md) describes the
-  generated artifact discovery contract, Artifacts tree grouping, context
-  actions, refresh behavior, empty states, and current limits.
-- [Initial Extension Design](design/initial-extension-design.md) describes the
-  proposed feature areas, VS Code surfaces, and implementation boundaries.
-- [Project Discovery](design/project-discovery.md) documents the passive
-  detection rules and capability model for GEnCor-style HDL projects.
-- [MVP Roadmap](design/mvp-roadmap.md) turns the design into a staged
-  implementation plan.
-- [CI GHDL Cache Strategy](design/ci-ghdl-cache.md) records how GitHub Actions
-  can cache a local dependency-managed GHDL toolchain for Doctor smoke tests.
-- [Git Flow](design/git-flow.md) records the repository branch model and how
-  GitHub Actions enforce it.
-- [GitHub Pages](design/pages.md) records the MkDocs build and Pages deployment
-  setup.
+  adapted by this repository.
 
 ## Current Direction
 

--- a/docs/agent/README.md
+++ b/docs/agent/README.md
@@ -1,0 +1,44 @@
+# Agent Harness
+
+The agent harness is the repo-local structure that lets Codex and other coding
+agents understand the project, choose the right work, make small changes, and
+prove those changes without relying on chat history or private context.
+
+This follows the harness engineering pattern described by OpenAI: keep the
+instruction entry point short, make repository knowledge the source of truth,
+and enforce repeatable rules with scripts and tests where possible.
+
+Reference: <https://openai.com/index/harness-engineering/>
+
+## Navigation
+
+| Need | Source |
+| --- | --- |
+| Repository instructions | `AGENTS.md` |
+| Architecture and module boundaries | `ARCHITECTURE.md` |
+| Issue queue, git-flow, commits, and evidence | `docs/agent/issue-workflow.md` |
+| Surface-specific validation commands | `docs/agent/validation.md` |
+| Active and completed execution plans | `docs/plans/README.md` |
+| Golden principles and recurring cleanup | `docs/quality/golden-principles.md` |
+| Known debt and follow-up candidates | `docs/quality/tech-debt-tracker.md` |
+| Reusable HDL workspaces | `test-fixtures/hdl-projects/` |
+
+## Agent Loop
+
+1. Read `AGENTS.md`, then follow the links for the touched surface.
+2. Identify the issue and branch type before editing.
+3. Read the relevant architecture, design, workflow, and evidence docs.
+4. Create or update an execution plan for multi-step work.
+5. Keep implementation changes narrow and issue-scoped.
+6. Run the validation commands for the touched surface.
+7. Record evidence in the issue, PR, or relevant docs.
+8. Commit a coherent chunk that references the issue number.
+
+## Repo-Local Skill
+
+This repo includes `.agents/skills/hdl-dev-issue-work/SKILL.md` for repeatable
+issue-scoped HDL Dev work. Use it when a task asks to implement, review, or
+finish a GitHub issue in this repository.
+
+The skill intentionally points back to this knowledge base instead of
+duplicating every rule. Update the docs first when the workflow changes.

--- a/docs/agent/issue-workflow.md
+++ b/docs/agent/issue-workflow.md
@@ -1,0 +1,183 @@
+# Issue Workflow
+
+HDL Dev uses issue-driven git-flow. Every implementation or documentation slice
+should be traceable to a GitHub issue unless a maintainer explicitly asks for an
+untracked experiment.
+
+## Finding Work
+
+Default to the GitHub Project queue when the user has not named a specific
+task:
+
+- Project: `HDL Dev Roadmap`
+  <https://github.com/users/cosgroma/projects/3>
+- View: `Ready Queue`
+- Filters and ordering: `Readiness = Ready`, sorted by `Recommended Order`
+- Repository: `cosgroma/vscode-hdl-dev`
+
+Useful CLI checks:
+
+```bash
+gh issue list \
+  --repo cosgroma/vscode-hdl-dev \
+  --state open \
+  --limit 100 \
+  --json number,title,milestone,labels,url
+```
+
+To inspect project planning fields from the CLI:
+
+```bash
+gh api graphql \
+  -f login=cosgroma \
+  -F number=3 \
+  -f query='
+query($login: String!, $number: Int!) {
+  user(login: $login) {
+    projectV2(number: $number) {
+      items(first: 50) {
+        nodes {
+          content { ... on Issue { number title url } }
+          fieldValues(first: 20) {
+            nodes {
+              ... on ProjectV2ItemFieldNumberValue {
+                number
+                field { ... on ProjectV2FieldCommon { name } }
+              }
+              ... on ProjectV2ItemFieldTextValue {
+                text
+                field { ... on ProjectV2FieldCommon { name } }
+              }
+              ... on ProjectV2ItemFieldSingleSelectValue {
+                name
+                field { ... on ProjectV2FieldCommon { name } }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}'
+```
+
+If the user requests new work that is not already tracked, create a focused
+issue before branching so the branch, commit, evidence, and handoff have a
+stable reference.
+
+## Git Flow
+
+Before starting work:
+
+```bash
+git fetch origin
+git checkout develop
+git pull --ff-only origin develop
+git status --short --branch
+```
+
+Branch model:
+
+- `main`: production branch and GitHub Pages deployment source.
+- `develop`: default branch and integration branch.
+- `feature/*`: normal feature work from `develop`.
+- `bugfix/*`: non-release bug fixes from `develop`.
+- `release/*`: release stabilization from `develop`, merged to `main` and
+  `develop`.
+- `hotfix/*`: urgent production fixes from `main`, merged to `main` and
+  `develop`.
+- `support/*`: long-lived maintenance branches when needed.
+
+Start normal feature work with:
+
+```bash
+git flow feature start <issue-number>-short-slug
+```
+
+Examples:
+
+```bash
+git flow feature start 1-project-discovery
+git flow feature start 2-dependency-doctor
+```
+
+Finish normal feature work back to `develop` only after review or when the
+maintainer explicitly asks:
+
+```bash
+git flow feature finish <issue-number>-short-slug
+git push origin develop
+```
+
+Do not commit feature work directly to `main`. `main` only accepts `release/*`
+and `hotfix/*` pull requests.
+
+## Commit Methodology
+
+Commit whenever a coherent chunk of work lands. A coherent chunk should compile
+or be clearly isolated documentation/planning work.
+
+Every commit that implements or documents issue-scoped work must reference the
+issue number in the commit message.
+
+Preferred commit message style:
+
+```text
+Add project discovery service (#1)
+Test dependency doctor trust handling (#2)
+Document v0.1 evidence checklist (#3)
+```
+
+Use closing keywords only in the final commit or PR that fully satisfies the
+issue:
+
+```text
+Complete Dependency Doctor workflow (fixes #2)
+```
+
+Do not use `fixes #N` for partial work. Use plain references like `refs #N`,
+`for #N`, or `(#N)` until the acceptance criteria and evidence checklist are
+complete.
+
+When a chunk lands:
+
+1. Run the relevant checks.
+2. Commit with the issue number in the message.
+3. Push the branch or `develop` when appropriate.
+4. Capture evidence in the issue or PR.
+5. Recommend the next chunk of work in the final response or handoff.
+
+## Evidence Requirements
+
+Issues are not done until their `Evidence Required` checklist is satisfied.
+Typical evidence includes:
+
+- CI run URL
+- Doctor smoke URL or local `make deps-check-ghdl` transcript
+- `make docs-build` output or Pages run URL
+- screenshots or short captures for visible VS Code surfaces
+- test output for the relevant service, command, or UI behavior
+- documentation updates where the issue changes user-facing behavior
+
+Use the GitHub Project `Evidence State` field:
+
+- `Needs Evidence`: implementation or proof is incomplete.
+- `Evidence Ready`: evidence has been collected and is ready for review.
+- `Accepted`: maintainer accepts the evidence and the issue can close.
+
+Milestone evidence gate issues must not close until all implementation issues in
+that milestone are closed or explicitly moved.
+
+## Handoff
+
+At the end of a work session, report:
+
+- issue number and title worked
+- files changed
+- checks run and whether they passed
+- commit SHA and branch
+- evidence added or still missing
+- recommended next issue or next chunk of work
+
+If work is incomplete, leave the branch in a clean, explainable state and state
+the next command or code area to inspect.

--- a/docs/agent/validation.md
+++ b/docs/agent/validation.md
@@ -1,0 +1,74 @@
+# Validation
+
+Pick checks that match the touched surface. Prefer fast, focused checks first,
+then broaden when a change touches shared behavior, extension activation,
+workflow configuration, or public docs.
+
+## Check Matrix
+
+| Touched surface | Run |
+| --- | --- |
+| Agent harness docs, plan docs, fixture docs, MkDocs nav | `make agent-harness-check` and `make docs-build` |
+| TypeScript extension behavior | `npm run lint`, `npm run compile`, and `npm test` |
+| Extension contribution metadata in `package.json` | `npm run compile` and `npm test` |
+| Dependency scripts or Doctor behavior | `make deps-check-ghdl`, `npm run lint`, `npm run compile`, and `npm test` |
+| GHDL bootstrap behavior | `make deps-install-ghdl` and `make deps-check-ghdl` |
+| Documentation site content | `make docs-build` |
+| GitHub Actions workflow YAML | the workflow YAML parse check below |
+| VS Code tree, command, or Testing API visible behavior | automated tests plus screenshot or short capture when the issue requires visible evidence |
+
+## Common Commands
+
+```bash
+npm run lint
+npm run compile
+npm test
+make docs-build
+make deps-check-ghdl
+make agent-harness-check
+```
+
+For workflow changes, parse workflow YAML:
+
+```bash
+python3 - <<'PY'
+import pathlib, yaml
+for path in pathlib.Path(".github/workflows").glob("*.yml"):
+    with path.open() as f:
+        yaml.safe_load(f)
+    print(f"ok {path}")
+PY
+```
+
+For dependency or Doctor changes, run:
+
+```bash
+make deps-install-ghdl
+make deps-check-ghdl
+```
+
+## Harness Check
+
+`make agent-harness-check` validates the structure that agents rely on:
+
+- required harness docs and directories exist
+- `AGENTS.md` remains a concise map
+- repo-local skill frontmatter is present
+- local Markdown links resolve
+- every Markdown file under `docs/` is represented in `mkdocs.yml`
+
+When this check fails, update the source docs or navigation instead of working
+around the validator.
+
+## Evidence Capture
+
+Record evidence in the issue, PR, or milestone evidence document. Good evidence
+is concrete and reproducible:
+
+- command transcripts for local checks
+- CI or Pages run URLs for hosted checks
+- screenshots for visible VS Code surfaces
+- fixture paths and exact commands for manual reproduction
+
+Keep generated evidence files in `docs/evidence/` only when they are intended to
+be versioned with the repository.

--- a/docs/design/index.md
+++ b/docs/design/index.md
@@ -1,0 +1,14 @@
+# Design Index
+
+Design docs describe intent, staged direction, and repository infrastructure
+decisions.
+
+- [Initial Extension Design](initial-extension-design.md) describes feature
+  areas, VS Code surfaces, and implementation boundaries.
+- [MVP Roadmap](mvp-roadmap.md) turns the design into staged milestones.
+- [Project Discovery](project-discovery.md) documents passive HDL project
+  detection and capabilities.
+- [CI GHDL Cache Strategy](ci-ghdl-cache.md) records the GitHub Actions cache
+  strategy for local GHDL tooling.
+- [Git Flow](git-flow.md) records the branch model and policy checks.
+- [GitHub Pages](pages.md) records the MkDocs build and Pages deployment setup.

--- a/docs/evidence/README.md
+++ b/docs/evidence/README.md
@@ -1,0 +1,25 @@
+# Evidence
+
+This directory stores versioned evidence artifacts that are useful to keep with
+the repository, such as screenshots for milestone evidence. Prefer issue or PR
+comments for long command transcripts and hosted CI links.
+
+## Naming
+
+Use filenames that include the issue number and what the artifact proves:
+
+```text
+issue-11-artifact-actions.png
+```
+
+## Evidence Checklist
+
+Good issue evidence usually includes:
+
+- local command output or CI run URLs for relevant checks
+- screenshots or short captures for visible VS Code surfaces
+- fixture paths and exact commands for manual reproduction
+- documentation links when behavior changes user-facing contracts
+
+Keep evidence small and focused. Do not check in generated output unless it is
+needed for review or future regression comparison.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -1,0 +1,27 @@
+# Execution Plans
+
+Execution plans are versioned task records for work that needs more structure
+than a short prompt. They let agents resume work without relying on chat history
+and keep decisions, progress, and evidence close to the code.
+
+## Layout
+
+```text
+docs/plans/
+  active/      in-progress issue plans and progress logs
+  completed/   historical plans that landed and no longer need updates
+  templates/   reusable plan templates
+```
+
+Use lightweight plans for small changes and fuller plans for multi-step issues,
+cross-module behavior, UI evidence, or work that may span multiple sessions.
+
+## Plan Rules
+
+- Name active plans with the issue number and short slug.
+- Keep acceptance criteria visible until the issue is accepted.
+- Update checkboxes and evidence notes as work proceeds.
+- Move a plan to `completed/` only when the issue is complete or a maintainer
+  explicitly closes the plan.
+- Prefer links to source docs, issue comments, and evidence artifacts instead of
+  copying long transcripts into the plan.

--- a/docs/plans/active/issue-30-agent-harness-structure.md
+++ b/docs/plans/active/issue-30-agent-harness-structure.md
@@ -1,0 +1,40 @@
+# Issue 30: Agent Harness Structure
+
+Issue: <https://github.com/cosgroma/vscode-hdl-dev/issues/30>
+
+## Goal
+
+Initialize a lightweight agent harness structure so future Codex runs can
+navigate the repository, choose work, validate changes, and collect evidence
+from versioned repo-local sources.
+
+## Scope
+
+- Keep `AGENTS.md` concise and link to deeper docs.
+- Add architecture, agent workflow, plan, quality, evidence, and directory
+  index docs.
+- Add a reusable HDL fixture workspace.
+- Add a cheap validator and Make target for harness structure and local docs
+  links.
+- Add a repo-local issue-work skill that points back to the harness docs.
+
+## Checklist
+
+- [x] `AGENTS.md` is reduced to a concise map.
+- [x] Harness docs and indexes are added under `docs/`.
+- [x] `ARCHITECTURE.md` captures module boundaries and source layout.
+- [x] A reusable HDL fixture is added under `test-fixtures/`.
+- [x] A repo-local skill is added under `.agents/skills/`.
+- [x] `make agent-harness-check` validates structure and links.
+- [x] `make docs-build` passes with the new MkDocs navigation.
+
+## Evidence
+
+- `make agent-harness-check` passed.
+- `make docs-build` passed with MkDocs strict mode.
+- `make -C test-fixtures/hdl-projects/minimal list-tbs` printed `timer_tb`.
+- `make -C test-fixtures/hdl-projects/minimal test TB=timer_tb STOP_TIME=20us WAVE_FORMAT=ghw` generated fixture run output.
+- `make -C test-fixtures/hdl-projects/minimal docs-waveforms WAVEFORM=timer-wave` completed.
+- `make -C test-fixtures/hdl-projects/minimal docs-schematics SCHEMATIC=timer-core` completed.
+- `test-fixtures/hdl-projects/minimal/scripts/deps.sh check ghdl` passed.
+- `test-fixtures/hdl-projects/minimal/scripts/deps.sh check docs-assets` passed.

--- a/docs/plans/completed/README.md
+++ b/docs/plans/completed/README.md
@@ -1,0 +1,7 @@
+# Completed Plans
+
+Move execution plans here after the issue is complete or a maintainer explicitly
+accepts the plan as finished.
+
+Keep completed plans for historical context when they capture decisions or
+evidence that future agents may need.

--- a/docs/plans/templates/issue-plan.md
+++ b/docs/plans/templates/issue-plan.md
@@ -1,0 +1,27 @@
+# Issue N: Short Title
+
+Issue: <https://github.com/cosgroma/vscode-hdl-dev/issues/N>
+
+## Goal
+
+State the user-visible or maintainer-visible outcome.
+
+## Scope
+
+- Include the files, modules, docs, or workflows expected to change.
+- Explicitly note out-of-scope follow-up work.
+
+## Checklist
+
+- [ ] Implementation or documentation item.
+- [ ] Focused tests or validation.
+- [ ] Evidence captured in the issue or PR.
+
+## Decisions
+
+Record decisions that future agents should not have to rediscover.
+
+## Evidence
+
+Record command names, pass/fail status, fixture paths, CI URLs, screenshots, or
+links to issue comments.

--- a/docs/quality/golden-principles.md
+++ b/docs/quality/golden-principles.md
@@ -1,0 +1,36 @@
+# Golden Principles
+
+These principles capture recurring architectural and workflow preferences that
+should shape future agent work. Promote a principle into a script, lint, or test
+when it becomes mechanically checkable.
+
+## Product And Workflow
+
+- HDL project repositories remain the source of truth. HDL Dev coordinates
+  local Make targets, scripts, specs, and generated artifacts rather than
+  replacing them.
+- Native VS Code surfaces come first: commands, Output channels, the Testing
+  API, tree views, status items, and normal editors.
+- Webviews should be focused artifact inspection tools, not the default UI
+  surface.
+- Public docs, design docs, workflow docs, plans, and evidence should be
+  versioned in the repository.
+
+## Safety And Reliability
+
+- Passive discovery must not execute workspace code.
+- Execution paths must respect workspace trust before running scripts or tools.
+- Shared project build directories require serialized command execution.
+- Raw command output should stay visible for diagnosis.
+- Machine-readable outputs should be added at the script boundary when the
+  extension needs reliable introspection.
+
+## Agent Legibility
+
+- `AGENTS.md` is a map, not a manual.
+- New durable knowledge belongs in structured docs or executable checks.
+- Reusable reproduction state belongs in `test-fixtures/`.
+- Repeated review feedback should become a doc rule, test, script, or lintable
+  invariant.
+- Prefer boring, inspectable dependencies and small local helpers when they make
+  behavior easier to reason about and test.

--- a/docs/quality/tech-debt-tracker.md
+++ b/docs/quality/tech-debt-tracker.md
@@ -1,0 +1,14 @@
+# Technical Debt Tracker
+
+Track known debt here when it is not yet ready for its own implementation issue
+or when it cuts across multiple milestones. Prefer creating a GitHub issue once
+the scope and evidence requirements are clear.
+
+| Area | Debt | Current handling | Candidate follow-up |
+| --- | --- | --- | --- |
+| Dependency Doctor | Doctor consumes human-readable script output and process exit status. | Preserve raw output and use coarse pass/fail status. | Add `scripts/deps.sh check <profile> --json` when extension introspection needs it. |
+| Toolchain bootstrap | Local GHDL bootstrap is Linux x86_64 first. | Document as a known limitation. | Add platform detection and non-Linux guidance. |
+| Specs | Waveform and schematic specs do not yet have JSON schemas. | Specs tree parses JSON and reports invalid files. | Implement schema files and validation commands. |
+| Artifacts | Latest-artifact command is planned but not implemented. | Artifact tree supports open, reveal, and copy-path actions. | Add command once artifact selection policy is defined. |
+| Preview | SVG previews use normal editors only. | Keep generated SVGs directly openable. | Add focused pan/zoom preview after artifact navigation is stable. |
+| Agent harness | Harness structure is new and only lightly validated. | `make agent-harness-check` validates required files, links, and MkDocs nav. | Add more structural checks only after repeated drift appears. |

--- a/docs/references/index.md
+++ b/docs/references/index.md
@@ -1,0 +1,8 @@
+# Reference Index
+
+Reference docs collect external API, UX, and integration sources that shape HDL
+Dev decisions.
+
+- [VS Code Workbench Surfaces](vscode-workbench-surfaces.md) records the
+  official VS Code API and UX references used for command, tree, Testing API,
+  trust, and workbench-surface decisions.

--- a/docs/workflows/index.md
+++ b/docs/workflows/index.md
@@ -1,0 +1,11 @@
+# Workflow Index
+
+Workflow docs record shipped behavior, script contracts, VS Code surfaces, and
+evidence expectations for each milestone.
+
+- [v0.1 Project Discovery And Dependency Doctor](v0.1-project-discovery-and-doctor.md)
+- [v0.2 Native Testbench Runner](v0.2-testbench-discovery.md)
+- [v0.2 Native Testbench Runner Evidence](v0.2-native-testbench-runner-evidence.md)
+- [v0.3 Specs Tree](v0.3-specs-tree.md)
+- [v0.3 Specs Tree Evidence](v0.3-specs-tree-evidence.md)
+- [v0.4 Artifact Explorer](v0.4-artifact-explorer.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,11 +11,28 @@ theme:
 
 nav:
   - Home: README.md
+  - Agent Harness:
+      - Overview: agent/README.md
+      - Issue Workflow: agent/issue-workflow.md
+      - Validation: agent/validation.md
+  - Plans:
+      - Overview: plans/README.md
+      - Active:
+          - Issue 30 Agent Harness Structure: plans/active/issue-30-agent-harness-structure.md
+      - Completed: plans/completed/README.md
+      - Templates:
+          - Issue Plan: plans/templates/issue-plan.md
+  - Quality:
+      - Golden Principles: quality/golden-principles.md
+      - Technical Debt Tracker: quality/tech-debt-tracker.md
+  - Evidence: evidence/README.md
   - References:
+      - Index: references/index.md
       - VS Code Workbench Surfaces: references/vscode-workbench-surfaces.md
   - Integrations:
       - GEnCor: integrations/gencor.md
   - Workflows:
+      - Index: workflows/index.md
       - v0.1 Project Discovery And Dependency Doctor: workflows/v0.1-project-discovery-and-doctor.md
       - v0.2 Native Testbench Runner: workflows/v0.2-testbench-discovery.md
       - v0.2 Native Testbench Runner Evidence: workflows/v0.2-native-testbench-runner-evidence.md
@@ -23,6 +40,7 @@ nav:
       - v0.3 Specs Tree Evidence: workflows/v0.3-specs-tree-evidence.md
       - v0.4 Artifact Explorer: workflows/v0.4-artifact-explorer.md
   - Design:
+      - Index: design/index.md
       - Project Discovery: design/project-discovery.md
       - Initial Extension Design: design/initial-extension-design.md
       - MVP Roadmap: design/mvp-roadmap.md

--- a/scripts/validate-agent-harness.mjs
+++ b/scripts/validate-agent-harness.mjs
@@ -1,0 +1,175 @@
+#!/usr/bin/env node
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+
+const root = process.cwd();
+const errors = [];
+
+const requiredPaths = [
+	['file', 'AGENTS.md'],
+	['file', 'ARCHITECTURE.md'],
+	['file', 'docs/agent/README.md'],
+	['file', 'docs/agent/issue-workflow.md'],
+	['file', 'docs/agent/validation.md'],
+	['file', 'docs/plans/README.md'],
+	['dir', 'docs/plans/active'],
+	['dir', 'docs/plans/completed'],
+	['file', 'docs/plans/completed/README.md'],
+	['file', 'docs/plans/templates/issue-plan.md'],
+	['file', 'docs/quality/golden-principles.md'],
+	['file', 'docs/quality/tech-debt-tracker.md'],
+	['file', 'docs/design/index.md'],
+	['file', 'docs/workflows/index.md'],
+	['file', 'docs/references/index.md'],
+	['file', 'docs/evidence/README.md'],
+	['file', '.agents/skills/hdl-dev-issue-work/SKILL.md'],
+	['file', 'test-fixtures/hdl-projects/minimal/Makefile'],
+	['file', 'test-fixtures/hdl-projects/minimal/scripts/deps.sh'],
+	['file', 'scripts/validate-agent-harness.mjs'],
+];
+
+for (const [kind, relativePath] of requiredPaths) {
+	await checkPath(kind, relativePath);
+}
+
+await checkAgentsLength();
+await checkSkillFrontmatter();
+await checkMarkdownLinks();
+await checkDocsNavCoverage();
+
+if (errors.length > 0) {
+	for (const error of errors) {
+		console.error(`[agent-harness] ${error}`);
+	}
+	process.exit(1);
+}
+
+console.log('[agent-harness] ok');
+
+async function checkPath(kind, relativePath) {
+	const fullPath = path.join(root, relativePath);
+	try {
+		const stat = await fs.stat(fullPath);
+		if (kind === 'file' && !stat.isFile()) {
+			errors.push(`${relativePath} must be a file`);
+		}
+		if (kind === 'dir' && !stat.isDirectory()) {
+			errors.push(`${relativePath} must be a directory`);
+		}
+	} catch {
+		errors.push(`missing required ${kind}: ${relativePath}`);
+	}
+}
+
+async function checkAgentsLength() {
+	const content = await fs.readFile(path.join(root, 'AGENTS.md'), 'utf8');
+	const lineCount = content.trimEnd().split('\n').length;
+	if (lineCount > 140) {
+		errors.push(`AGENTS.md should stay concise; found ${lineCount} lines, expected 140 or fewer`);
+	}
+}
+
+async function checkSkillFrontmatter() {
+	const skillPath = path.join(root, '.agents/skills/hdl-dev-issue-work/SKILL.md');
+	const content = await fs.readFile(skillPath, 'utf8');
+	if (!content.startsWith('---\n')) {
+		errors.push('.agents/skills/hdl-dev-issue-work/SKILL.md must start with YAML frontmatter');
+		return;
+	}
+	if (!/^name:\s*hdl-dev-issue-work$/m.test(content)) {
+		errors.push('.agents/skills/hdl-dev-issue-work/SKILL.md must declare name: hdl-dev-issue-work');
+	}
+	if (!/^description:\s*.+$/m.test(content)) {
+		errors.push('.agents/skills/hdl-dev-issue-work/SKILL.md must declare a description');
+	}
+}
+
+async function checkMarkdownLinks() {
+	const markdownFiles = await findMarkdownFiles(root);
+	for (const filePath of markdownFiles) {
+		const content = await fs.readFile(filePath, 'utf8');
+		const withoutCodeBlocks = content.replace(/```[\s\S]*?```/g, '');
+		const linkPattern = /(?<!!)\[[^\]]+\]\(([^)]+)\)/g;
+		for (const match of withoutCodeBlocks.matchAll(linkPattern)) {
+			const destination = match[1].trim();
+			const target = parseMarkdownDestination(destination);
+			if (target === undefined || target === '' || isExternalTarget(target)) {
+				continue;
+			}
+
+			const targetPath = target.split('#')[0];
+			if (targetPath === '') {
+				continue;
+			}
+
+			const resolved = path.resolve(path.dirname(filePath), decodeURI(targetPath));
+			try {
+				await fs.stat(resolved);
+			} catch {
+				errors.push(`${relative(filePath)} links to missing path: ${target}`);
+			}
+		}
+	}
+}
+
+async function checkDocsNavCoverage() {
+	const mkdocs = await fs.readFile(path.join(root, 'mkdocs.yml'), 'utf8');
+	const docsFiles = await findMarkdownFiles(path.join(root, 'docs'));
+	for (const filePath of docsFiles) {
+		const docsRelativePath = relative(path.relative(path.join(root, 'docs'), filePath));
+		if (!mkdocs.includes(docsRelativePath)) {
+			errors.push(`mkdocs.yml does not include docs page: ${docsRelativePath}`);
+		}
+	}
+}
+
+async function findMarkdownFiles(startPath) {
+	const results = [];
+	await walk(startPath, results);
+	return results.sort((left, right) => left.localeCompare(right));
+}
+
+async function walk(currentPath, results) {
+	const entries = await fs.readdir(currentPath, { withFileTypes: true });
+	for (const entry of entries) {
+		const fullPath = path.join(currentPath, entry.name);
+		if (entry.isDirectory()) {
+			if (shouldSkipDirectory(entry.name)) {
+				continue;
+			}
+			await walk(fullPath, results);
+			continue;
+		}
+		if (entry.isFile() && entry.name.endsWith('.md')) {
+			results.push(fullPath);
+		}
+	}
+}
+
+function shouldSkipDirectory(name) {
+	return [
+		'.cache',
+		'.git',
+		'.vscode-test',
+		'node_modules',
+		'out',
+		'site',
+	].includes(name);
+}
+
+function parseMarkdownDestination(destination) {
+	if (destination.startsWith('<') && destination.endsWith('>')) {
+		return destination.slice(1, -1);
+	}
+	const match = /^(\S+)/.exec(destination);
+	return match?.[1];
+}
+
+function isExternalTarget(target) {
+	return /^[a-z][a-z0-9+.-]*:/i.test(target);
+}
+
+function relative(filePath) {
+	return path.relative(root, filePath).split(path.sep).join('/');
+}

--- a/test-fixtures/hdl-projects/minimal/Makefile
+++ b/test-fixtures/hdl-projects/minimal/Makefile
@@ -1,0 +1,34 @@
+SHELL := /bin/bash
+.SHELLFLAGS := -eu -o pipefail -c
+.DEFAULT_GOAL := help
+
+TB ?= timer_tb
+STOP_TIME ?= 500us
+WAVE_FORMAT ?= ghw
+WAVEFORM ?= timer-wave
+SCHEMATIC ?= timer-core
+
+.PHONY: help
+help:
+	@printf "Fixture targets: list-tbs, test, docs-waveforms, docs-schematics\n"
+
+.PHONY: list-tbs
+list-tbs:
+	@printf "timer_tb\n"
+
+.PHONY: test
+test:
+	@mkdir -p build/waves logs
+	@printf "fixture run TB=%s STOP_TIME=%s WAVE_FORMAT=%s\n" "$(TB)" "$(STOP_TIME)" "$(WAVE_FORMAT)" | tee "logs/$(TB).log"
+	@printf "fixture wave dump for %s\n" "$(TB)" > "build/waves/$(TB).$(WAVE_FORMAT)"
+
+.PHONY: docs-waveforms
+docs-waveforms:
+	@mkdir -p docs/waveforms/generated
+	@printf '<svg xmlns="http://www.w3.org/2000/svg" width="320" height="80"><text x="12" y="44">%s fixture waveform</text></svg>\n' "$(WAVEFORM)" > "docs/waveforms/generated/$(WAVEFORM).svg"
+
+.PHONY: docs-schematics
+docs-schematics:
+	@mkdir -p docs/schematics/generated "build/schematics/$(SCHEMATIC)"
+	@printf '<svg xmlns="http://www.w3.org/2000/svg" width="320" height="80"><text x="12" y="44">%s fixture schematic</text></svg>\n' "$(SCHEMATIC)" > "docs/schematics/generated/$(SCHEMATIC).svg"
+	@printf '{"fixture":true,"schematic":"%s"}\n' "$(SCHEMATIC)" > "build/schematics/$(SCHEMATIC)/$(SCHEMATIC).json"

--- a/test-fixtures/hdl-projects/minimal/README.md
+++ b/test-fixtures/hdl-projects/minimal/README.md
@@ -1,0 +1,21 @@
+# Minimal HDL Fixture
+
+This fixture is a small HDL project shape for tests, manual reproduction, and
+agent evidence. It intentionally uses local Make targets and a fixture
+dependency script so HDL Dev can exercise project discovery, testbench
+discovery, spec generation, and artifact navigation without external HDL tools.
+
+Useful commands from this directory:
+
+```bash
+make list-tbs
+make test TB=timer_tb STOP_TIME=20us WAVE_FORMAT=ghw
+make docs-waveforms WAVEFORM=timer-wave
+make docs-waveforms WAVEFORM=timer-wave NO_RUN=1
+make docs-schematics SCHEMATIC=timer-core
+scripts/deps.sh check ghdl
+scripts/deps.sh check docs-assets
+```
+
+The generated files are lightweight text/SVG placeholders. They are not
+simulation-accurate artifacts.

--- a/test-fixtures/hdl-projects/minimal/build/csv/results.csv
+++ b/test-fixtures/hdl-projects/minimal/build/csv/results.csv
@@ -1,0 +1,2 @@
+name,value
+timer_tb,pass

--- a/test-fixtures/hdl-projects/minimal/build/schematics/timer-core/timer-core.json
+++ b/test-fixtures/hdl-projects/minimal/build/schematics/timer-core/timer-core.json
@@ -1,0 +1,1 @@
+{"fixture":true,"schematic":"timer-core"}

--- a/test-fixtures/hdl-projects/minimal/build/waves/timer_tb.ghw
+++ b/test-fixtures/hdl-projects/minimal/build/waves/timer_tb.ghw
@@ -1,0 +1,1 @@
+fixture wave dump for timer_tb

--- a/test-fixtures/hdl-projects/minimal/docs/schematics/generated/timer-core.svg
+++ b/test-fixtures/hdl-projects/minimal/docs/schematics/generated/timer-core.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="320" height="80"><text x="12" y="44">timer-core fixture schematic</text></svg>

--- a/test-fixtures/hdl-projects/minimal/docs/schematics/specs/timer-core.json
+++ b/test-fixtures/hdl-projects/minimal/docs/schematics/specs/timer-core.json
@@ -1,0 +1,7 @@
+{
+  "name": "timer-core",
+  "top": "timer_core",
+  "include": [
+    "timer_core"
+  ]
+}

--- a/test-fixtures/hdl-projects/minimal/docs/waveforms/generated/timer-wave.svg
+++ b/test-fixtures/hdl-projects/minimal/docs/waveforms/generated/timer-wave.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="320" height="80"><text x="12" y="44">timer-wave fixture waveform</text></svg>

--- a/test-fixtures/hdl-projects/minimal/docs/waveforms/specs/timer-wave.json
+++ b/test-fixtures/hdl-projects/minimal/docs/waveforms/specs/timer-wave.json
@@ -1,0 +1,14 @@
+{
+  "name": "timer-wave",
+  "testbench": "timer_tb",
+  "signals": [
+    {
+      "path": "/timer_tb/clk",
+      "label": "clk"
+    },
+    {
+      "path": "/timer_tb/rst",
+      "label": "rst"
+    }
+  ]
+}

--- a/test-fixtures/hdl-projects/minimal/logs/plots/latency.svg
+++ b/test-fixtures/hdl-projects/minimal/logs/plots/latency.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="320" height="80"><text x="12" y="44">fixture latency plot</text></svg>

--- a/test-fixtures/hdl-projects/minimal/logs/timer_tb.log
+++ b/test-fixtures/hdl-projects/minimal/logs/timer_tb.log
@@ -1,0 +1,1 @@
+fixture run TB=timer_tb STOP_TIME=20us WAVE_FORMAT=ghw

--- a/test-fixtures/hdl-projects/minimal/scripts/deps.sh
+++ b/test-fixtures/hdl-projects/minimal/scripts/deps.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+command_name="${1:-}"
+profile="${2:-}"
+
+case "$command_name" in
+	list)
+		printf "ghdl\n"
+		printf "docs-assets\n"
+		;;
+	check)
+		case "$profile" in
+			ghdl)
+				printf "[ok] fixture ghdl dependencies available\n"
+				printf "[ok] fixture ghwdump supports -H hierarchy output\n"
+				;;
+			docs-assets)
+				printf "[ok] fixture docs asset dependencies available\n"
+				;;
+			*)
+				printf "[error] unsupported fixture dependency profile: %s\n" "$profile" >&2
+				exit 2
+				;;
+		esac
+		;;
+	*)
+		printf "usage: %s list | check <ghdl|docs-assets>\n" "$0" >&2
+		exit 2
+		;;
+esac


### PR DESCRIPTION
## Summary

- shorten `AGENTS.md` into a concise agent map and move durable workflow detail into repo docs
- add `ARCHITECTURE.md`, agent workflow docs, plan/quality/evidence indexes, and MkDocs navigation
- add `make agent-harness-check`, a repo-local HDL Dev issue-work skill, and a reusable minimal HDL fixture workspace

## Validation

- `make agent-harness-check`
- `make docs-build`
- `git diff --cached --check`
- `make -C test-fixtures/hdl-projects/minimal list-tbs`
- `make -C test-fixtures/hdl-projects/minimal test TB=timer_tb STOP_TIME=20us WAVE_FORMAT=ghw`
- `make -C test-fixtures/hdl-projects/minimal docs-waveforms WAVEFORM=timer-wave`
- `make -C test-fixtures/hdl-projects/minimal docs-schematics SCHEMATIC=timer-core`
- `test-fixtures/hdl-projects/minimal/scripts/deps.sh check ghdl`
- `test-fixtures/hdl-projects/minimal/scripts/deps.sh check docs-assets`

Fixes #30