### PR TITLE
Document Artifact Explorer evidence (#12)

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ Design notes live under `docs/` and are published through MkDocs:
 - [v0.3 Specs Tree](docs/workflows/v0.3-specs-tree.md)
 - [v0.3 Specs Tree Evidence](docs/workflows/v0.3-specs-tree-evidence.md)
 - [v0.4 Artifact Explorer](docs/workflows/v0.4-artifact-explorer.md)
+- [v0.4 Artifact Explorer Evidence](docs/workflows/v0.4-artifact-explorer-evidence.md)
 - [Project Discovery](docs/design/project-discovery.md)
 - [Initial Extension Design](docs/design/initial-extension-design.md)
 - [MVP Roadmap](docs/design/mvp-roadmap.md)

--- a/docs/plans/active/issue-12-artifact-evidence.md
+++ b/docs/plans/active/issue-12-artifact-evidence.md
@@ -1,0 +1,63 @@
+# Issue 12: Artifact Explorer Evidence
+
+Issue: <https://github.com/cosgroma/vscode-hdl-dev/issues/12>
+
+## Goal
+
+Close the v0.4 Artifact Explorer milestone evidence gap by documenting the
+artifact directory contract, shipped behavior, automated coverage, fixture
+evidence, and manual UI evidence for generated artifact navigation.
+
+## Scope
+
+- Add a v0.4 Artifact Explorer evidence page.
+- Link the evidence page from MkDocs and repository docs indexes.
+- Reuse the `test-fixtures/hdl-projects/minimal` workspace for reproducible
+  artifact evidence.
+- Record local validation and issue evidence.
+
+Out of scope:
+
+- New Artifact Explorer feature work.
+- New screenshot capture unless existing versioned evidence is insufficient.
+- Preview/webview work, latest-artifact command work, or stale-artifact work.
+
+## Checklist
+
+- [x] Evidence page documents artifact directories and producing commands.
+- [x] Evidence page records automated test coverage for discovery, grouping,
+  actions, refresh, and empty/error states.
+- [x] Evidence page records fixture-backed manual artifact evidence.
+- [x] Existing screenshot evidence is referenced for the visible Artifacts tree
+  and context actions.
+- [x] MkDocs navigation includes the evidence page.
+- [x] Local checks pass.
+- [x] Issue evidence comment is added.
+
+## Decisions
+
+- Reuse `docs/evidence/issue-11-artifact-actions.png` for the v0.4 milestone
+  screenshot because it already shows the populated Artifacts tree and the
+  artifact context menu.
+- Keep this slice documentation/evidence-only; implementation issues `#10` and
+  `#11` already landed and are accepted.
+
+## Evidence
+
+Fixture smoke evidence collected:
+
+- `make -C test-fixtures/hdl-projects/minimal list-tbs` printed `timer_tb`.
+- `make -C test-fixtures/hdl-projects/minimal test TB=timer_tb STOP_TIME=20us WAVE_FORMAT=ghw` completed and produced `build/waves/timer_tb.ghw`.
+- `make -C test-fixtures/hdl-projects/minimal docs-waveforms WAVEFORM=timer-wave` completed and produced `docs/waveforms/generated/timer-wave.svg`.
+- `make -C test-fixtures/hdl-projects/minimal docs-schematics SCHEMATIC=timer-core` completed and produced `docs/schematics/generated/timer-core.svg` plus `build/schematics/timer-core/timer-core.json`.
+- `test-fixtures/hdl-projects/minimal/scripts/deps.sh check ghdl` passed.
+- `test-fixtures/hdl-projects/minimal/scripts/deps.sh check docs-assets` passed.
+- `find test-fixtures/hdl-projects/minimal/build test-fixtures/hdl-projects/minimal/docs test-fixtures/hdl-projects/minimal/logs -type f | sort` showed all seven artifact groups.
+
+Local validation:
+
+- `npm run lint` passed.
+- `npm run compile` passed.
+- `npm test` passed with 51 tests.
+- `make docs-build` passed with MkDocs strict mode.
+- `make agent-harness-check` passed.

--- a/docs/workflows/index.md
+++ b/docs/workflows/index.md
@@ -9,3 +9,4 @@ evidence expectations for each milestone.
 - [v0.3 Specs Tree](v0.3-specs-tree.md)
 - [v0.3 Specs Tree Evidence](v0.3-specs-tree-evidence.md)
 - [v0.4 Artifact Explorer](v0.4-artifact-explorer.md)
+- [v0.4 Artifact Explorer Evidence](v0.4-artifact-explorer-evidence.md)

--- a/docs/workflows/v0.4-artifact-explorer-evidence.md
+++ b/docs/workflows/v0.4-artifact-explorer-evidence.md
@@ -1,0 +1,163 @@
+# v0.4 Artifact Explorer Evidence
+
+Issue: <https://github.com/cosgroma/vscode-hdl-dev/issues/12>
+
+The v0.4 Artifact Explorer milestone is the native generated-artifact navigation
+loop for HDL Dev. It builds on the artifact discovery model from issue `#10`
+and the open/reveal/copy action integration from issue `#11`.
+
+## Shipped Scope
+
+The milestone ships:
+
+- generated artifact discovery for wave dumps, waveform SVGs, schematic SVGs,
+  schematic JSON, logs, plots, and CSV outputs
+- an `Artifacts` tree under the `HDL` Activity Bar container
+- artifact groups that stay visible as empty states when directories are missing
+- stable artifact IDs based on project root, artifact kind, and absolute path
+- manual refresh plus refresh integration after testbench and spec-generation
+  commands
+- artifact context actions for open, reveal in file explorer, and copy path
+- normal-editor opening for supported artifact files
+
+Out of scope for v0.4:
+
+- latest-artifact command
+- stale-artifact indicators
+- custom SVG preview webviews
+- packetized-I/O debug session grouping
+
+## Directory Contract
+
+Artifact discovery scans these project-local paths:
+
+| Artifact group | Path or glob | Producing workflow |
+| --- | --- | --- |
+| Wave Dumps | `build/waves/*.ghw`, `*.fst`, `*.vcd` | `make test TB=<name> STOP_TIME=<time> WAVE_FORMAT=<format>` |
+| Waveform SVGs | `docs/waveforms/generated/*.svg` | `make docs-waveforms WAVEFORM=<name>` |
+| Schematic SVGs | `docs/schematics/generated/*.svg` | `make docs-schematics SCHEMATIC=<name>` |
+| Schematic JSON | `build/schematics/**/*.json` | `make docs-schematics SCHEMATIC=<name>` |
+| Logs | `logs/**/*.log`, `logs/**/*.txt` | testbench, generation, or debug workflows |
+| Plots | `logs/plots/*.{svg,png,jpg,jpeg,pdf}` | debug or analysis workflows |
+| CSV Outputs | `build/csv/**/*.csv` | debug or analysis workflows |
+
+Missing directories are normal. The tree keeps the group and displays an
+actionable empty state, such as running a testbench to produce wave dumps.
+
+## Automated Coverage
+
+Relevant tests:
+
+- `src/test/artifactDiscovery.test.ts`
+- `src/test/artifactsTree.test.ts`
+- `src/test/artifactCommands.test.ts`
+- `src/test/specGeneration.test.ts`
+- `src/test/testbenchRun.test.ts`
+
+Coverage includes:
+
+- discovery of all seven artifact groups
+- stable artifact IDs
+- missing directories reported as empty groups
+- large artifact group capping
+- project, group, artifact, and status tree items
+- package contributions for the Artifacts view and refresh command
+- open, reveal, and copy-path commands
+- actionable errors for missing or unselected artifacts
+- refresh after successful waveform/schematic generation
+- refresh after completed testbench runs
+
+## Fixture Evidence
+
+The reusable fixture workspace lives at:
+
+```text
+test-fixtures/hdl-projects/minimal
+```
+
+It contains all seven artifact groups:
+
+```text
+build/waves/timer_tb.ghw
+docs/waveforms/generated/timer-wave.svg
+docs/schematics/generated/timer-core.svg
+build/schematics/timer-core/timer-core.json
+logs/timer_tb.log
+logs/plots/latency.svg
+build/csv/results.csv
+```
+
+Fixture smoke commands:
+
+```bash
+make -C test-fixtures/hdl-projects/minimal list-tbs
+make -C test-fixtures/hdl-projects/minimal test TB=timer_tb STOP_TIME=20us WAVE_FORMAT=ghw
+make -C test-fixtures/hdl-projects/minimal docs-waveforms WAVEFORM=timer-wave
+make -C test-fixtures/hdl-projects/minimal docs-schematics SCHEMATIC=timer-core
+test-fixtures/hdl-projects/minimal/scripts/deps.sh check ghdl
+test-fixtures/hdl-projects/minimal/scripts/deps.sh check docs-assets
+```
+
+The fixture is intentionally lightweight. It proves the extension-facing project
+shape and artifact paths without requiring external HDL tools.
+
+## Manual UI Evidence
+
+Versioned screenshot evidence:
+
+```text
+docs/evidence/issue-11-artifact-actions.png
+```
+
+That screenshot shows:
+
+- the `Artifacts` tree populated from a fixture workspace
+- all seven artifact groups visible with counts
+- at least three artifact types visible in the same tree
+- a selected CSV artifact
+- the context actions `Open Artifact`, `Reveal Artifact in File Explorer`, and
+  `Copy Artifact Path`
+
+The screenshot was captured during issue `#11`, which implemented artifact
+actions and refresh integration. It remains valid milestone evidence for issue
+`#12` because it demonstrates the completed v0.4 Artifact Explorer surface.
+
+## Validation Checklist
+
+Before marking issue `#12` evidence-ready, run:
+
+```bash
+npm run lint
+npm run compile
+npm test
+make docs-build
+make agent-harness-check
+```
+
+For hosted evidence, attach the PR CI run URL after opening the pull request.
+
+## Local Evidence Run
+
+Local validation collected on the issue `#12` evidence branch:
+
+| Check | Result |
+| --- | --- |
+| `npm run lint` | Passed |
+| `npm run compile` | Passed |
+| `npm test` | Passed, 51 tests |
+| `make docs-build` | Passed with MkDocs strict mode |
+| `make agent-harness-check` | Passed |
+
+Fixture smoke evidence:
+
+| Command | Result |
+| --- | --- |
+| `make -C test-fixtures/hdl-projects/minimal list-tbs` | Printed `timer_tb` |
+| `make -C test-fixtures/hdl-projects/minimal test TB=timer_tb STOP_TIME=20us WAVE_FORMAT=ghw` | Produced `build/waves/timer_tb.ghw` |
+| `make -C test-fixtures/hdl-projects/minimal docs-waveforms WAVEFORM=timer-wave` | Produced `docs/waveforms/generated/timer-wave.svg` |
+| `make -C test-fixtures/hdl-projects/minimal docs-schematics SCHEMATIC=timer-core` | Produced `docs/schematics/generated/timer-core.svg` and `build/schematics/timer-core/timer-core.json` |
+| `test-fixtures/hdl-projects/minimal/scripts/deps.sh check ghdl` | Passed |
+| `test-fixtures/hdl-projects/minimal/scripts/deps.sh check docs-assets` | Passed |
+
+Hosted CI evidence should be added from the pull request before closing the
+issue.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,6 +18,7 @@ nav:
   - Plans:
       - Overview: plans/README.md
       - Active:
+          - Issue 12 Artifact Evidence: plans/active/issue-12-artifact-evidence.md
           - Issue 30 Agent Harness Structure: plans/active/issue-30-agent-harness-structure.md
       - Completed: plans/completed/README.md
       - Templates:
@@ -39,6 +40,7 @@ nav:
       - v0.3 Specs Tree: workflows/v0.3-specs-tree.md
       - v0.3 Specs Tree Evidence: workflows/v0.3-specs-tree-evidence.md
       - v0.4 Artifact Explorer: workflows/v0.4-artifact-explorer.md
+      - v0.4 Artifact Explorer Evidence: workflows/v0.4-artifact-explorer-evidence.md
   - Design:
       - Index: design/index.md
       - Project Discovery: design/project-discovery.md


### PR DESCRIPTION
## Summary

- add the v0.4 Artifact Explorer evidence page for issue #12
- document artifact directory conventions, producing commands, automated coverage, fixture smoke evidence, and manual UI evidence
- link the evidence page from README, workflow index, and MkDocs navigation

## Validation

- `npm run lint`
- `npm run compile`
- `npm test` (51 passing tests)
- `make docs-build`
- `make agent-harness-check`
- `make -C test-fixtures/hdl-projects/minimal list-tbs`
- `make -C test-fixtures/hdl-projects/minimal test TB=timer_tb STOP_TIME=20us WAVE_FORMAT=ghw`
- `make -C test-fixtures/hdl-projects/minimal docs-waveforms WAVEFORM=timer-wave`
- `make -C test-fixtures/hdl-projects/minimal docs-schematics SCHEMATIC=timer-core`
- `test-fixtures/hdl-projects/minimal/scripts/deps.sh check ghdl`
- `test-fixtures/hdl-projects/minimal/scripts/deps.sh check docs-assets`

## Evidence

- local evidence comment: https://github.com/cosgroma/vscode-hdl-dev/issues/12#issuecomment-4887279244
- manual UI screenshot reused from `docs/evidence/issue-11-artifact-actions.png`

Fixes #12